### PR TITLE
Refactoring to cache data modifications

### DIFF
--- a/sensemap/src/components/Breadcrumb/index.tsx
+++ b/sensemap/src/components/Breadcrumb/index.tsx
@@ -5,12 +5,15 @@ import { connect } from 'react-redux';
 import { Segment, Breadcrumb as SBreadcrumb } from 'semantic-ui-react';
 import * as T from '../../types';
 import { actions, ActionProps, mapDispatch } from '../../types';
+import { emptyBoxData } from '../../types/sense/box';
+import { MapScope } from '../../types/sense-map';
+import * as CS from '../../types/cached-storage';
 import * as R from '../../types/routes';
 
 interface StateFromProps {
   history: History;
-  scope: typeof T.initial.senseMap.scope;
-  boxes: typeof T.initial.senseObject.boxes;
+  senseObject: CS.CachedStorage;
+  scope: MapScope;
   bid: string;
 }
 
@@ -46,11 +49,8 @@ class Breadcrumb extends React.PureComponent<Props> {
   }
 
   render() {
-    const { actions: { senseMap, selection }, scope, boxes, bid } = this.props;
-    let box = { title: bid };
-    if (scope.type === T.MapScopeType.BOX) {
-      box = boxes[scope.box] || box;
-    }
+    const { actions: { senseMap, selection }, senseObject, scope, bid } = this.props;
+    const box = CS.getBox(senseObject, bid);
 
     return (
       <Segment compact className="breadcrumb">
@@ -59,7 +59,11 @@ class Breadcrumb extends React.PureComponent<Props> {
             scope.type === T.MapScopeType.BOX &&
               (
                 <React.Fragment>
-                  <SBreadcrumb.Section active>{box.title}</SBreadcrumb.Section>
+                  <SBreadcrumb.Section active>{
+                    box === emptyBoxData
+                      ? bid
+                      : box.title
+                  }</SBreadcrumb.Section>
                   <SBreadcrumb.Divider icon="left angle" />
                 </React.Fragment>
               )
@@ -89,12 +93,12 @@ class Breadcrumb extends React.PureComponent<Props> {
 
 export default withRouter(connect<StateFromProps, ActionProps, RouterProps>(
   (state: T.State, router) => {
-    const { boxes } = state.senseObject;
+    const { senseObject } = state;
     const { scope } = state.senseMap;
     const { history } = router;
     const { bid } = router.match.params;
 
-    return { history, scope, boxes, bid };
+    return { history, senseObject, scope, bid };
   },
   mapDispatch({ actions })
 )(Breadcrumb));

--- a/sensemap/src/components/Map/Box/index.tsx
+++ b/sensemap/src/components/Map/Box/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Group, Rect } from 'react-konva';
+import { Group, Rect, Circle } from 'react-konva';
 import Header from './Header';
 import Card from './Card';
 import Toggle from './Toggle';
@@ -19,6 +19,7 @@ const toggleListDisplay = (d: ListDisplay) =>
   d === ListDisplay.EXPANDED ? ListDisplay.COLLAPSED : ListDisplay.EXPANDED;
 
 interface Props {
+  isDirty?: boolean;
   mapObject: T.ObjectData;
   box: T.BoxData;
   cards: ObjectMap<T.CardData>;
@@ -42,6 +43,10 @@ interface State {
 
 const width = B.DEFAULT_WIDTH;
 const height = B.DEFAULT_HEIGHT;
+
+const dirtyRadius = 5;
+const dirtyPadding = 10;
+const dirtyColor = '#3ad8fa';
 
 const selectedOffsetX = -8;
 const selectedOffsetY = -8;
@@ -81,7 +86,7 @@ class Box extends React.Component<Props, State> {
       x: this.props.mapObject.x,
       y: this.props.mapObject.y,
     });
-    const { box } = this.props;
+    const { box, isDirty = false } = this.props;
     const cards = Object.values(this.props.cards);
 
     const handleSelect    = this.props.handleSelect    || noop;
@@ -139,6 +144,15 @@ class Box extends React.Component<Props, State> {
       >
         {this.props.selected ? selected : null}
         <Header box={box} x={0} y={0} />
+        {
+          isDirty &&
+          <Circle
+            x={width - dirtyPadding}
+            y={dirtyPadding}
+            radius={dirtyRadius}
+            fill={dirtyColor}
+          />
+        }
         {this.state.listDisplay === ListDisplay.COLLAPSED
           ? null : boxCards(this.props, cards)}
         <Toggle

--- a/sensemap/src/components/Map/Box/index.tsx
+++ b/sensemap/src/components/Map/Box/index.tsx
@@ -4,6 +4,7 @@ import Header from './Header';
 import Card from './Card';
 import Toggle from './Toggle';
 import * as T from '../../../types';
+import { ObjectMap } from '../../../types/sense/has-id';
 import * as B from '../../../types/sense/box';
 import { noop } from '../../../types/utils';
 import { Event as KonvaEvent } from '../../../types/konva';
@@ -20,7 +21,7 @@ const toggleListDisplay = (d: ListDisplay) =>
 interface Props {
   mapObject: T.ObjectData;
   box: T.BoxData;
-  cards: T.State['senseObject']['cards'];
+  cards: ObjectMap<T.CardData>;
   selected?: Boolean;
   transform: G.Transform;
   inverseTransform: G.Transform;

--- a/sensemap/src/components/Map/Card/index.tsx
+++ b/sensemap/src/components/Map/Card/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Group, Rect, Text } from 'react-konva';
+import { Group, Rect, Circle, Text } from 'react-konva';
 import TagList from '../TagList';
 import * as T from '../../../types';
 import * as C from '../../../types/sense/card';
@@ -8,6 +8,7 @@ import { Event as KonvaEvent } from '../../../types/konva';
 import * as G from '../../../graphics/point';
 
 interface Props {
+  isDirty?: boolean;
   mapObject: T.ObjectData;
   card: T.CardData;
   selected?: Boolean;
@@ -29,6 +30,10 @@ interface State {
 const width = C.DEFAULT_WIDTH;
 const height = C.DEFAULT_HEIGHT;
 const cornerRadius = 4;
+
+const dirtyRadius = 5;
+const dirtyPadding = 10;
+const dirtyColor = '#3ad8fa';
 
 const summaryPadding = 0;
 const summaryOffsetX = 10 - summaryPadding;
@@ -84,6 +89,7 @@ class Card extends React.Component<Props, State> {
   };
 
   render() {
+    const { isDirty = false } = this.props;
     const { data } = this.props.mapObject;
     const { x, y } = this.props.transform({
       x: this.props.mapObject.x,
@@ -155,6 +161,15 @@ class Card extends React.Component<Props, State> {
           shadowOffsetY={shadowOffsetY}
           shadowColor={shadowColor}
         />
+        {
+          isDirty &&
+          <Circle
+            x={width - dirtyPadding}
+            y={dirtyPadding}
+            radius={dirtyRadius}
+            fill={dirtyColor}
+          />
+        }
         <Text
           x={summaryOffsetX}
           y={summaryOffsetY}

--- a/sensemap/src/components/Map/index.tsx
+++ b/sensemap/src/components/Map/index.tsx
@@ -206,6 +206,7 @@ export class Map extends React.Component<Props, MapState> {
         return (
           <Card
             key={o.id}
+            isDirty={CS.isCardDirty(this.props.inScope, o.data)}
             mapObject={o}
             transform={transform}
             inverseTransform={inverseTransform}
@@ -226,6 +227,7 @@ export class Map extends React.Component<Props, MapState> {
         return (
           <Box
             key={o.id}
+            isDirty={CS.isBoxDirty(this.props.inScope, o.data)}
             mapObject={o}
             transform={transform}
             inverseTransform={inverseTransform}

--- a/sensemap/src/components/Map/index.tsx
+++ b/sensemap/src/components/Map/index.tsx
@@ -7,6 +7,7 @@ import Edge from './Edge';
 import { Group } from 'react-konva';
 import * as SL from '../../types/selection';
 import { Edge as EdgeData, ObjectType, ObjectData, State, ActionProps } from '../../types';
+import { ObjectMap } from '../../types/sense/has-id';
 import * as I from '../../types/input';
 import * as OE from '../../types/object-editor';
 import * as O from '../../types/sense/object';
@@ -20,8 +21,8 @@ import { Event as KonvaEvent } from '../../types/konva';
 
 export interface StateFromProps {
   selection:   State['selection'];
-  senseObject: State['senseObject'];
-  inScope:     State['senseObject'];
+  senseObject: S.Storage;
+  inScope:     S.Storage;
   input:       State['input'];
   stage:       State['stage'];
 }
@@ -33,12 +34,12 @@ export interface OwnProps extends ViewportState {}
 export type Props = StateFromProps & ActionProps & OwnProps;
 
 interface MapState {
-  inScope: State['senseObject'];
+  inScope: S.Storage;
   objectDragStart: {
     x: number,
     y: number,
   };
-  dropTarget: State['senseObject']['objects'];
+  dropTarget: ObjectMap<ObjectData>;
 }
 
 const makeTransform: V.StateToTransform =

--- a/sensemap/src/components/Map/index.tsx
+++ b/sensemap/src/components/Map/index.tsx
@@ -11,7 +11,7 @@ import * as I from '../../types/input';
 import * as OE from '../../types/object-editor';
 import * as O from '../../types/sense/object';
 import * as F from '../../types/sense/focus';
-import * as SO from '../../types/sense-object';
+import * as S from '../../types/storage';
 import * as V from '../../types/viewport';
 import * as G from '../../graphics/point';
 import * as B from '../../types/sense/box';
@@ -132,7 +132,7 @@ export class Map extends React.Component<Props, MapState> {
     const dx = e.evt.layerX - this.state.objectDragStart.x;
     const dy = e.evt.layerY - this.state.objectDragStart.y;
     const objects = this.props.selection.map(id => {
-      const o = SO.getObject(this.props.senseObject, id);
+      const o = S.getObject(this.props.senseObject, id);
       return { ...o, x: o.x + dx, y: o.y + dy };
     }).reduce((a, o) => { a[o.id] = o; return a; }, {});
     this.setState({
@@ -149,7 +149,7 @@ export class Map extends React.Component<Props, MapState> {
     const dx = e.evt.layerX - this.state.objectDragStart.x;
     const dy = e.evt.layerY - this.state.objectDragStart.y;
     this.props.selection.forEach(id => {
-      const o = SO.getObject(this.props.senseObject, id);
+      const o = S.getObject(this.props.senseObject, id);
       this.props.actions.senseObject.moveObject(id, o.x + dx, o.y + dy);
     });
     this.setState({ objectDragStart: { x: 0, y: 0 } });
@@ -198,7 +198,7 @@ export class Map extends React.Component<Props, MapState> {
     const handleObjectDeselect = (data: ObjectData) => {
       acts.selection.removeObjectFromSelection(data.id);
       if (this.props.selection.length === 1) {
-        acts.editor.focusObject(O.toFocus(SO.getObject(this.props.senseObject, this.props.selection[0])));
+        acts.editor.focusObject(O.toFocus(S.getObject(this.props.senseObject, this.props.selection[0])));
       } else {
         acts.editor.focusObject(F.focusNothing());
       }
@@ -209,7 +209,7 @@ export class Map extends React.Component<Props, MapState> {
         return <Group key={o.id} />;
       }
       case ObjectType.CARD: {
-        if (!SO.doesCardExist(this.props.inScope, o.data)) {
+        if (!S.doesCardExist(this.props.inScope, o.data)) {
           return <Group key={o.id} />;
         }
         return (
@@ -218,7 +218,7 @@ export class Map extends React.Component<Props, MapState> {
             mapObject={o}
             transform={transform}
             inverseTransform={inverseTransform}
-            card={SO.getCard(this.props.senseObject, o.data)}
+            card={S.getCard(this.props.senseObject, o.data)}
             selected={isSelected}
             handleSelect={handleObjectSelect}
             handleDeselect={handleObjectDeselect}
@@ -229,7 +229,7 @@ export class Map extends React.Component<Props, MapState> {
           />);
       }
       case ObjectType.BOX: {
-        if (!SO.doesBoxExist(this.props.inScope, o.data)) {
+        if (!S.doesBoxExist(this.props.inScope, o.data)) {
           return <Group key={o.id} />;
         }
         return (
@@ -238,8 +238,8 @@ export class Map extends React.Component<Props, MapState> {
             mapObject={o}
             transform={transform}
             inverseTransform={inverseTransform}
-            box={SO.getBox(this.props.senseObject, o.data)}
-            cards={SO.getCardsInBox(this.props.senseObject, o.data)}
+            box={S.getBox(this.props.senseObject, o.data)}
+            cards={S.getCardsInBox(this.props.senseObject, o.data)}
             selected={isSelected}
             handleSelect={handleObjectSelect}
             handleDeselect={handleObjectDeselect}
@@ -262,8 +262,8 @@ export class Map extends React.Component<Props, MapState> {
 
   renderEdge(e: EdgeData) {
     const edgeProps = {
-      from: getCenter(SO.getObject(this.state.inScope, e.from)),
-      to: getCenter(SO.getObject(this.state.inScope, e.to)),
+      from: getCenter(S.getObject(this.state.inScope, e.from)),
+      to: getCenter(S.getObject(this.state.inScope, e.to)),
       transform: makeTransform(this.props),
       inverseTransform: makeInverseTransform(this.props),
     };

--- a/sensemap/src/components/MapPage/index.tsx
+++ b/sensemap/src/components/MapPage/index.tsx
@@ -12,6 +12,7 @@ import { CardData, BoxData, ObjectType, MapScopeType, State, actions, ActionProp
 import * as OE from '../../types/object-editor';
 import * as SM from '../../types/sense-map';
 import * as SO from '../../types/sense-object';
+import * as S from '../../types/storage';
 import { Action as BoxAction } from '../../types/sense/box';
 import { Action as CardAction } from '../../types/sense/card';
 import * as F from '../../types/sense/focus';
@@ -62,14 +63,14 @@ class MapPage extends React.Component<Props> {
     let doesDataExist: boolean = false;
     switch (focus.objectType) {
       case ObjectType.BOX:
-        data = SO.getBoxOrDefault(editor.temp, senseObject, focus.data);
-        isDirty = SO.doesBoxExist(editor.temp, focus.data);
-        doesDataExist = SO.doesBoxExist(senseObject, focus.data);
+        data = S.getBoxOrDefault(editor.temp, senseObject, focus.data);
+        isDirty = S.doesBoxExist(editor.temp, focus.data);
+        doesDataExist = S.doesBoxExist(senseObject, focus.data);
         break;
       case ObjectType.CARD:
-        data = SO.getCardOrDefault(editor.temp, senseObject, focus.data);
-        isDirty = SO.doesCardExist(editor.temp, focus.data);
-        doesDataExist = SO.doesCardExist(senseObject, focus.data);
+        data = S.getCardOrDefault(editor.temp, senseObject, focus.data);
+        isDirty = S.doesCardExist(editor.temp, focus.data);
+        doesDataExist = S.doesCardExist(senseObject, focus.data);
         break;
       default:
     }

--- a/sensemap/src/components/MapPage/index.tsx
+++ b/sensemap/src/components/MapPage/index.tsx
@@ -125,7 +125,7 @@ class MapPage extends React.Component<Props> {
                         const action =
                           // tslint:disable-next-line:no-any
                           await acts.senseObject.createCardObject(senseMap.map, newData as CardData) as any;
-                        const { payload: objects } = action as ReturnType<typeof SO.actions.updateObjects>;
+                        const { payload: objects } = action as ReturnType<typeof S.actions.updateObjects>;
                         if (scope.type === MapScopeType.BOX) {
                           const obj = Object.values(objects)[0];
                           const boxId = scope.box;

--- a/sensemap/src/components/MapPage/index.tsx
+++ b/sensemap/src/components/MapPage/index.tsx
@@ -71,17 +71,17 @@ class MapPage extends React.Component<Props> {
 
     let data: BoxData | CardData | null = null;
     let isDirty: boolean = false;
-    let doesDataExist: boolean = false;
+    let isNew: boolean = false;
     switch (focus.objectType) {
       case ObjectType.BOX:
         data = CS.getBox(senseObject, focus.data);
         isDirty = CS.isBoxDirty(senseObject, focus.data);
-        doesDataExist = CS.doesBoxExist(senseObject, focus.data);
+        isNew = CS.isBoxNew(senseObject, focus.data);
         break;
       case ObjectType.CARD:
         data = CS.getCard(senseObject, focus.data);
         isDirty = CS.isCardDirty(senseObject, focus.data);
-        doesDataExist = CS.doesCardExist(senseObject, focus.data);
+        isNew = CS.isCardNew(senseObject, focus.data);
         break;
       default:
     }
@@ -97,9 +97,9 @@ class MapPage extends React.Component<Props> {
               <ObjectContent
                 objectType={focus.objectType}
                 data={data}
-                submitText={doesDataExist ? '更新' : '送出'}
-                submitDisabled={!isDirty}
-                cancelDisabled={!isDirty}
+                submitText={isNew ? '送出' : '更新'}
+                submitDisabled={!isDirty && !isNew}
+                cancelDisabled={!isDirty && !isNew}
                 onUpdate={action => {
                   if (data === null) {
                     return;
@@ -120,7 +120,7 @@ class MapPage extends React.Component<Props> {
                   }
                 }}
                 onSubmit={async (newData) => {
-                  if (doesDataExist) {
+                  if (!isNew) {
                     // should update the object
                     switch (focus.objectType) {
                       case ObjectType.CARD:
@@ -170,7 +170,7 @@ class MapPage extends React.Component<Props> {
                       default:
                     }
                   }
-                  if (!doesDataExist) {
+                  if (isNew) {
                     acts.editor.focusObject(F.focusNothing());
                     acts.editor.changeStatus(OE.StatusType.HIDE);
                   }

--- a/sensemap/src/components/MapPage/index.tsx
+++ b/sensemap/src/components/MapPage/index.tsx
@@ -109,11 +109,11 @@ class MapPage extends React.Component<Props> {
                     // should update the object
                     switch (focus.objectType) {
                       case ObjectType.CARD:
-                        await acts.senseObject.updateRemoteCard(newData as CardData);
+                        await acts.senseObject.updateCard(newData as CardData);
                         acts.editor.clearObject(focus.objectType, focus.data);
                         break;
                       case ObjectType.BOX:
-                        await acts.senseObject.updateRemoteBox(newData as BoxData);
+                        await acts.senseObject.updateBox(newData as BoxData);
                         acts.editor.clearObject(focus.objectType, focus.data);
                         break;
                       default:
@@ -125,7 +125,7 @@ class MapPage extends React.Component<Props> {
                         const action =
                           // tslint:disable-next-line:no-any
                           await acts.senseObject.createCardObject(senseMap.map, newData as CardData) as any;
-                        const { payload: objects } = action as ReturnType<typeof S.actions.updateObjects>;
+                        const { payload: { objects } } = action as ReturnType<typeof S.actions.updateObjects>;
                         if (scope.type === MapScopeType.BOX) {
                           const obj = Object.values(objects)[0];
                           const boxId = scope.box;

--- a/sensemap/src/components/ObjectMenu/index.tsx
+++ b/sensemap/src/components/ObjectMenu/index.tsx
@@ -5,7 +5,7 @@ import * as T from '../../types';
 import { actions, ActionProps, mapDispatch } from '../../types';
 import * as SL from '../../types/selection';
 import * as SM from '../../types/sense-map';
-import * as SO from '../../types/sense-object';
+import * as S from '../../types/storage';
 import * as OE from '../../types/object-editor';
 import { cardData } from '../../types/sense/card';
 import { boxData } from '../../types/sense/box';
@@ -29,7 +29,7 @@ const selectedCardsAndBoxes:
   (props: Props) => { cards: T.ObjectID[], boxes: T.ObjectID[] } =
   props => props.selection.reduce(
     (acc, id) => {
-      switch (SO.getObject(props.senseObject, id).objectType) {
+      switch (S.getObject(props.senseObject, id).objectType) {
         case T.ObjectType.CARD: {
           return { ...acc, cards: [ ...acc.cards, id ] };
         }
@@ -247,7 +247,7 @@ class ObjectMenu extends React.PureComponent<Props> {
           <Menu.Item
             name="deleteCard"
             onClick={async () => {
-              const { objectType, id } = SO.getObject(senseObject, selection[0]);
+              const { objectType, id } = S.getObject(senseObject, selection[0]);
               await acts.senseObject.deleteObject(id);
               acts.editor.focusObject(F.focusNothing());
               acts.editor.clearObject(objectType, id);

--- a/sensemap/src/components/ObjectMenu/index.tsx
+++ b/sensemap/src/components/ObjectMenu/index.tsx
@@ -160,7 +160,7 @@ class ObjectMenu extends React.PureComponent<Props> {
     if (r === null) {
       return;
     }
-    r.forEach(edge => this.props.actions.senseObject.deleteEdge(map, edge));
+    r.forEach(edge => this.props.actions.senseObject.removeEdge(map, edge));
   }
 
   render() {
@@ -248,7 +248,7 @@ class ObjectMenu extends React.PureComponent<Props> {
             name="deleteCard"
             onClick={async () => {
               const { objectType, id } = S.getObject(senseObject, selection[0]);
-              await acts.senseObject.deleteObject(id);
+              await acts.senseObject.removeObject(id);
               acts.editor.focusObject(F.focusNothing());
               acts.editor.clearObject(objectType, id);
             }}

--- a/sensemap/src/containers/Inbox/index.tsx
+++ b/sensemap/src/containers/Inbox/index.tsx
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import { State, actions, ActionProps, mapDispatch } from '../../types';
+import * as CS from '../../types/cached-storage';
 import * as CO from '../../components/Inbox';
 
 export default connect<CO.StateFromProps, ActionProps, CO.OwnProps>(
   (state: State) => {
-    const cards = Array(...Object.values(state.senseObject.cards))
+    const cards = Array(...Object.values(CS.toStorage(state.senseObject).cards))
       .sort((a, b) => b.updatedAt - a.updatedAt);
     return {
       cards,

--- a/sensemap/src/containers/Map/index.tsx
+++ b/sensemap/src/containers/Map/index.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import * as CO from '../../components/Map';
 import { MapScopeType, MapID, BoxID, State, actions, ActionProps, mapDispatch } from '../../types';
 import * as S from '../../types/storage';
+import * as CS from '../../types/cached-storage';
 
 interface StateFromProps extends CO.StateFromProps {
   scope: { type: MapScopeType, box?: BoxID };
@@ -36,8 +37,8 @@ class Map extends React.Component<Props> {
 export default connect<StateFromProps, ActionProps, OwnProps>(
   (state: State) => ({
     selection: state.selection,
-    senseObject: state.senseObject,
-    inScope: state.senseObject,
+    senseObject: CS.toStorage(state.senseObject),
+    inScope: CS.toStorage(state.senseObject),
     scope: state.senseMap.scope,
     input: state.input,
     stage: state.stage,

--- a/sensemap/src/containers/Map/index.tsx
+++ b/sensemap/src/containers/Map/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import * as CO from '../../components/Map';
 import { MapScopeType, MapID, BoxID, State, actions, ActionProps, mapDispatch } from '../../types';
-import * as S from '../../types/storage';
 import * as CS from '../../types/cached-storage';
 
 interface StateFromProps extends CO.StateFromProps {
@@ -27,9 +26,9 @@ class Map extends React.Component<Props> {
     const inScope =
       (this.props.scope.type === MapScopeType.BOX
       && !!this.props.scope.box
-      && S.doesBoxExist(this.props.senseObject, this.props.scope.box))
-        ? S.scopedToBox(this.props.senseObject, this.props.scope.box)
-        : S.scopedToMap(this.props.senseObject);
+      && CS.doesBoxExist(this.props.senseObject, this.props.scope.box))
+        ? CS.scopedToBox(this.props.senseObject, this.props.scope.box)
+        : CS.scopedToMap(this.props.senseObject);
     return <CO.Map {...this.props} inScope={inScope} />;
   }
 }
@@ -37,8 +36,8 @@ class Map extends React.Component<Props> {
 export default connect<StateFromProps, ActionProps, OwnProps>(
   (state: State) => ({
     selection: state.selection,
-    senseObject: CS.toStorage(state.senseObject),
-    inScope: CS.toStorage(state.senseObject),
+    senseObject: state.senseObject,
+    inScope: state.senseObject,
     scope: state.senseMap.scope,
     input: state.input,
     stage: state.stage,

--- a/sensemap/src/containers/Map/index.tsx
+++ b/sensemap/src/containers/Map/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import * as CO from '../../components/Map';
 import { MapScopeType, MapID, BoxID, State, actions, ActionProps, mapDispatch } from '../../types';
-import * as SO from '../../types/sense-object';
+import * as S from '../../types/storage';
 
 interface StateFromProps extends CO.StateFromProps {
   scope: { type: MapScopeType, box?: BoxID };
@@ -26,9 +26,9 @@ class Map extends React.Component<Props> {
     const inScope =
       (this.props.scope.type === MapScopeType.BOX
       && !!this.props.scope.box
-      && SO.doesBoxExist(this.props.senseObject, this.props.scope.box))
-        ? SO.scopedToBox(this.props.senseObject, this.props.scope.box)
-        : SO.scopedToMap(this.props.senseObject);
+      && S.doesBoxExist(this.props.senseObject, this.props.scope.box))
+        ? S.scopedToBox(this.props.senseObject, this.props.scope.box)
+        : S.scopedToMap(this.props.senseObject);
     return <CO.Map {...this.props} inScope={inScope} />;
   }
 }

--- a/sensemap/src/types/cached-storage.ts
+++ b/sensemap/src/types/cached-storage.ts
@@ -208,31 +208,6 @@ export const updateInBox =
     payload: { cardObject, box, target },
   });
 
-const FLUSH = 'FLUSH';
-export const flush = () => ({
-  type: FLUSH as typeof FLUSH,
-});
-
-const FLUSH_OBJECTS = 'FLUSH_OBJECTS';
-export const flushObjects = () => ({
-  type: FLUSH_OBJECTS as typeof FLUSH_OBJECTS,
-});
-
-const FLUSH_CARDS = 'FLUSH_CARDS';
-export const flushCards = () => ({
-  type: FLUSH_CARDS as typeof FLUSH_CARDS,
-});
-
-const FLUSH_BOXES = 'FLUSH_BOXES';
-export const flushBoxes = () => ({
-  type: FLUSH_BOXES as typeof FLUSH_BOXES,
-});
-
-const FLUSH_EDGES = 'FLUSH_EDGES';
-export const flushEdges = () => ({
-  type: FLUSH_EDGES as typeof FLUSH_EDGES,
-});
-
 export const actions = {
   updateObjects,
   overwriteObjects,
@@ -252,11 +227,6 @@ export const actions = {
   removeEdge,
   updateInBox,
   updateNotInBox,
-  flush,
-  flushObjects,
-  flushCards,
-  flushBoxes,
-  flushEdges,
 };
 
 export type Action = ActionUnion<typeof actions>;
@@ -282,61 +252,6 @@ export const reducer = (state: CachedStorage = initial, action: Action = emptyAc
       return {
         ...state,
         [target]: S.reducer(state[target], action),
-      };
-    }
-    case FLUSH: {
-      return {
-        [TargetType.PERMANENT]: toStorage(state),
-        [TargetType.TEMPORARY]: S.initial,
-      };
-    }
-    case FLUSH_OBJECTS: {
-      return {
-        [TargetType.PERMANENT]: {
-          ...state[TargetType.PERMANENT],
-          objects: {
-            ...state[TargetType.PERMANENT].objects,
-            ...state[TargetType.TEMPORARY].objects,
-          }
-        },
-        [TargetType.TEMPORARY]: S.initial,
-      };
-    }
-    case FLUSH_CARDS: {
-      return {
-        [TargetType.PERMANENT]: {
-          ...state[TargetType.PERMANENT],
-          cards: {
-            ...state[TargetType.PERMANENT].cards,
-            ...state[TargetType.TEMPORARY].cards,
-          }
-        },
-        [TargetType.TEMPORARY]: S.initial,
-      };
-
-    }
-    case FLUSH_BOXES: {
-      return {
-        [TargetType.PERMANENT]: {
-          ...state[TargetType.PERMANENT],
-          boxes: {
-            ...state[TargetType.PERMANENT].boxes,
-            ...state[TargetType.TEMPORARY].boxes,
-          }
-        },
-        [TargetType.TEMPORARY]: S.initial,
-      };
-    }
-    case FLUSH_EDGES: {
-      return {
-        [TargetType.PERMANENT]: {
-          ...state[TargetType.PERMANENT],
-          edges: {
-            ...state[TargetType.PERMANENT].edges,
-            ...state[TargetType.TEMPORARY].edges,
-          }
-        },
-        [TargetType.TEMPORARY]: S.initial,
       };
     }
     default: {

--- a/sensemap/src/types/cached-storage.ts
+++ b/sensemap/src/types/cached-storage.ts
@@ -106,18 +106,20 @@ export const isBoxDirty = (storage: CachedStorage, id: BoxID): boolean =>
 export const isEdgeDirty = (storage: CachedStorage, id: EdgeID): boolean =>
   S.doesEdgeExist(storage[TargetType.TEMPORARY], id) && S.doesEdgeExist(storage[TargetType.PERMANENT], id);
 
-export const scoped = (storage: CachedStorage, filter: (key: ObjectID) => boolean): S.Storage =>
-  S.scoped(toStorage(storage), filter);
+export const scoped = (storage: CachedStorage, filter: (key: ObjectID) => boolean): CachedStorage => ({
+  [TargetType.PERMANENT]: S.scoped(storage[TargetType.PERMANENT], filter),
+  [TargetType.TEMPORARY]: S.scoped(storage[TargetType.TEMPORARY], filter),
+});
 
 // XXX: duplicated
-export const scopedToBox = (storage: CachedStorage, id: BoxID): S.Storage => {
+export const scopedToBox = (storage: CachedStorage, id: BoxID): CachedStorage => {
   const { contains } = getBox(storage, id);
   const filter = (key: ObjectID): boolean => !!contains[key];
   return scoped(storage, filter);
 };
 
 // XXX: duplicated
-export const scopedToMap = (storage: CachedStorage): S.Storage => {
+export const scopedToMap = (storage: CachedStorage): CachedStorage => {
   const filter = (key: ObjectID): boolean => !getObject(storage, key).belongsTo;
   return scoped(storage, filter);
 };

--- a/sensemap/src/types/cached-storage.ts
+++ b/sensemap/src/types/cached-storage.ts
@@ -1,6 +1,6 @@
 import { ActionUnion, emptyAction } from './action';
 import * as S from './storage';
-import { ObjectMap } from './sense/has-id';
+import { ObjectMap, toIDMap } from './sense/has-id';
 import { ObjectID, ObjectData, emptyObjectData } from './sense/object';
 import { CardID, CardData, emptyCardData } from './sense/card';
 import { BoxID, BoxData, emptyBoxData } from './sense/box';
@@ -122,65 +122,77 @@ export const scopedToMap = (storage: CachedStorage): S.Storage => {
   return scoped(storage, filter);
 };
 
-const updateObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const updateObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.UPDATE_OBJECTS as typeof S.UPDATE_OBJECTS,
   payload: { objects, target },
 });
 
-const overwriteObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const overwriteObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.OVERWRITE_OBJECTS as typeof S.OVERWRITE_OBJECTS,
   payload: { objects, target },
 });
 
-const removeObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.REMOVE_OBJECTS as typeof S.REMOVE_OBJECTS,
   payload: { objects, target },
 });
 
-const updateCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeObject = (object: ObjectData, target: TargetType = TargetType.TEMPORARY) =>
+  removeObjects(toIDMap<ObjectID, ObjectData>([object]));
+
+export const updateCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.UPDATE_CARDS as typeof S.UPDATE_CARDS,
   payload: { cards, target },
 });
 
-const overwriteCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const overwriteCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.OVERWRITE_CARDS as typeof S.OVERWRITE_CARDS,
   payload: { cards, target },
 });
 
-const removeCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.REMOVE_CARDS as typeof S.REMOVE_CARDS,
   payload: { cards, target },
 });
 
-const updateBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeCard = (card: CardData, target: TargetType = TargetType.TEMPORARY) =>
+  removeCards(toIDMap<CardID, CardData>([card]));
+
+export const updateBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.UPDATE_BOXES as typeof S.UPDATE_BOXES,
   payload: { boxes, target },
 });
 
-const overwriteBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const overwriteBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.OVERWRITE_BOXES as typeof S.OVERWRITE_BOXES,
   payload: { boxes, target },
 });
 
-const removeBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.REMOVE_BOXES as typeof S.REMOVE_BOXES,
   payload: { boxes, target },
 });
 
-const updateEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeBox = (box: BoxData, target: TargetType = TargetType.TEMPORARY) =>
+  removeBoxes(toIDMap<BoxID, BoxData>([box]));
+
+export const updateEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.UPDATE_EDGES as typeof S.UPDATE_EDGES,
   payload: { edges, target },
 });
 
-const overwriteEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+export const overwriteEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.OVERWRITE_EDGES as typeof S.OVERWRITE_EDGES,
   payload: { edges, target },
 });
 
-const removeEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+export const removeEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
   type: S.REMOVE_EDGES as typeof S.REMOVE_EDGES,
   payload: { edges, target },
 });
+
+export const removeEdge = (edge: Edge, target: TargetType = TargetType.TEMPORARY) =>
+  removeEdges(toIDMap<EdgeID, Edge>([edge]));
 
 export const updateNotInBox =
   (cardObject: ObjectID, box: BoxID, target: TargetType = TargetType.TEMPORARY) => ({
@@ -195,27 +207,27 @@ export const updateInBox =
   });
 
 const FLUSH = 'FLUSH';
-const flush = () => ({
+export const flush = () => ({
   type: FLUSH as typeof FLUSH,
 });
 
 const FLUSH_OBJECTS = 'FLUSH_OBJECTS';
-const flushObjects = () => ({
+export const flushObjects = () => ({
   type: FLUSH_OBJECTS as typeof FLUSH_OBJECTS,
 });
 
 const FLUSH_CARDS = 'FLUSH_CARDS';
-const flushCards = () => ({
+export const flushCards = () => ({
   type: FLUSH_CARDS as typeof FLUSH_CARDS,
 });
 
 const FLUSH_BOXES = 'FLUSH_BOXES';
-const flushBoxes = () => ({
+export const flushBoxes = () => ({
   type: FLUSH_BOXES as typeof FLUSH_BOXES,
 });
 
 const FLUSH_EDGES = 'FLUSH_EDGES';
-const flushEdges = () => ({
+export const flushEdges = () => ({
   type: FLUSH_EDGES as typeof FLUSH_EDGES,
 });
 
@@ -223,15 +235,19 @@ export const actions = {
   updateObjects,
   overwriteObjects,
   removeObjects,
+  removeObject,
   updateCards,
   overwriteCards,
   removeCards,
+  removeCard,
   updateBoxes,
   overwriteBoxes,
   removeBoxes,
+  removeBox,
   updateEdges,
   overwriteEdges,
   removeEdges,
+  removeEdge,
   updateInBox,
   updateNotInBox,
   flush,

--- a/sensemap/src/types/cached-storage.ts
+++ b/sensemap/src/types/cached-storage.ts
@@ -1,0 +1,236 @@
+import { ActionUnion, emptyAction } from './action';
+import * as S from './storage';
+import { ObjectMap } from './sense/has-id';
+import { ObjectID, ObjectData, emptyObjectData } from './sense/object';
+import { CardID, CardData, emptyCardData } from './sense/card';
+import { BoxID, BoxData, emptyBoxData } from './sense/box';
+import { EdgeID, Edge, emptyEdge } from './sense/edge';
+
+/**
+ * It is a storage with delayed updates.
+ *
+ * @todo Should model it with class-based OO?
+ */
+export type CachedStorage = {
+  s: S.Storage,
+  _: S.Storage,
+};
+
+export const initial = {
+  s: S.initial,
+  _: S.initial,
+};
+
+export const toStorage = (storage: CachedStorage): S.Storage => {
+  return {
+    objects: {
+      ...storage.s.objects,
+      ...storage._.objects,
+    },
+    cards: {
+      ...storage.s.cards,
+      ...storage._.cards,
+    },
+    boxes: {
+      ...storage.s.boxes,
+      ...storage._.boxes,
+    },
+    edges: {
+      ...storage.s.edges,
+      ...storage._.edges,
+    },
+  };
+};
+
+export const getObject =
+  (storage: CachedStorage, id: ObjectID): ObjectData =>
+  storage._.objects[id] || storage.s.objects[id] || emptyObjectData;
+
+export const getCard =
+  (storage: CachedStorage, id: CardID): CardData =>
+  storage._.cards[id] || storage.s.cards[id] || emptyCardData;
+
+export const getBox =
+  (storage: CachedStorage, id: BoxID): BoxData =>
+  storage._.boxes[id] || storage.s.boxes[id] || emptyBoxData;
+
+export const getEdge =
+  (storage: CachedStorage, id: EdgeID): Edge =>
+  storage._.edges[id] || storage.s.edges[id] || emptyEdge;
+
+// XXX: duplicated
+export const getCardsInBox = (storage: CachedStorage, id: BoxID): ObjectMap<CardData> =>
+  Object.keys(getBox(storage, id).contains)
+    .map(oid => getObject(storage, oid).data )
+    .map(cid => getCard(storage, cid))
+    .reduce((a, c) => { a[c.id] = c; return a; }, {});
+
+export const doesObjectExist = (storage: CachedStorage, id: ObjectID): boolean =>
+  S.doesObjectExist(storage._, id) || S.doesObjectExist(storage.s, id);
+
+export const doesCardExist = (storage: CachedStorage, id: CardID): boolean =>
+  S.doesCardExist(storage._, id) || S.doesCardExist(storage.s, id);
+
+export const doesBoxExist = (storage: CachedStorage, id: BoxID): boolean =>
+  S.doesBoxExist(storage._, id) || S.doesBoxExist(storage.s, id);
+
+export const doesEdgeExist = (storage: CachedStorage, id: EdgeID): boolean =>
+  S.doesEdgeExist(storage._, id) || S.doesEdgeExist(storage.s, id);
+
+export const isObjectNew = (storage: CachedStorage, id: ObjectID): boolean =>
+  S.doesObjectExist(storage._, id) && !S.doesObjectExist(storage.s, id);
+
+export const isCardNew = (storage: CachedStorage, id: CardID): boolean =>
+  S.doesCardExist(storage._, id) && !S.doesCardExist(storage.s, id);
+
+export const isBoxNew = (storage: CachedStorage, id: BoxID): boolean =>
+  S.doesBoxExist(storage._, id) && !S.doesBoxExist(storage.s, id);
+
+export const isEdgeNew = (storage: CachedStorage, id: EdgeID): boolean =>
+  S.doesEdgeExist(storage._, id) && !S.doesEdgeExist(storage.s, id);
+
+export const isObjectDirty = (storage: CachedStorage, id: ObjectID): boolean =>
+  S.doesObjectExist(storage._, id) && S.doesObjectExist(storage.s, id);
+
+export const isCardDirty = (storage: CachedStorage, id: CardID): boolean =>
+  S.doesCardExist(storage._, id) && S.doesCardExist(storage.s, id);
+
+export const isBoxDirty = (storage: CachedStorage, id: BoxID): boolean =>
+  S.doesBoxExist(storage._, id) && S.doesBoxExist(storage.s, id);
+
+export const isEdgeDirty = (storage: CachedStorage, id: EdgeID): boolean =>
+  S.doesEdgeExist(storage._, id) && S.doesEdgeExist(storage.s, id);
+
+export const scoped = (storage: CachedStorage, filter: (key: ObjectID) => boolean): S.Storage =>
+  S.scoped(toStorage(storage), filter);
+
+// XXX: duplicated
+export const scopedToBox = (storage: CachedStorage, id: BoxID): S.Storage => {
+  const { contains } = getBox(storage, id);
+  const filter = (key: ObjectID): boolean => !!contains[key];
+  return scoped(storage, filter);
+};
+
+// XXX: duplicated
+export const scopedToMap = (storage: CachedStorage): S.Storage => {
+  const filter = (key: ObjectID): boolean => !getObject(storage, key).belongsTo;
+  return scoped(storage, filter);
+};
+
+const FLUSH = 'FLUSH';
+const flush = () => ({
+  type: FLUSH as typeof FLUSH,
+});
+
+const FLUSH_OBJECTS = 'FLUSH_OBJECTS';
+const flushObjects = () => ({
+  type: FLUSH_OBJECTS as typeof FLUSH_OBJECTS,
+});
+
+const FLUSH_CARDS = 'FLUSH_CARDS';
+const flushCards = () => ({
+  type: FLUSH_CARDS as typeof FLUSH_CARDS,
+});
+
+const FLUSH_BOXES = 'FLUSH_BOXES';
+const flushBoxes = () => ({
+  type: FLUSH_BOXES as typeof FLUSH_BOXES,
+});
+
+const FLUSH_EDGES = 'FLUSH_EDGES';
+const flushEdges = () => ({
+  type: FLUSH_EDGES as typeof FLUSH_EDGES,
+});
+
+export const actions = {
+  ...S.actions,
+  flush,
+  flushObjects,
+  flushCards,
+  flushBoxes,
+  flushEdges,
+};
+
+export type Action = ActionUnion<typeof actions>;
+
+export const reducer = (state: CachedStorage = initial, action: Action = emptyAction): CachedStorage => {
+  switch (action.type) {
+    case S.UPDATE_OBJECTS:
+    case S.OVERWRITE_OBJECTS:
+    case S.REMOVE_OBJECTS:
+    case S.UPDATE_CARDS:
+    case S.OVERWRITE_CARDS:
+    case S.REMOVE_CARDS:
+    case S.UPDATE_BOXES:
+    case S.OVERWRITE_BOXES:
+    case S.REMOVE_BOXES:
+    case S.UPDATE_EDGES:
+    case S.OVERWRITE_EDGES:
+    case S.REMOVE_EDGES:
+    case S.UPDATE_NOT_IN_BOX:
+    case S.UPDATE_IN_BOX: {
+      return {
+        s: state.s,
+        _: S.reducer(state._, action),
+      };
+    }
+    case FLUSH: {
+      return {
+        s: toStorage(state),
+        _: S.initial,
+      };
+    }
+    case FLUSH_OBJECTS: {
+      return {
+        s: {
+          ...state.s,
+          objects: {
+            ...state.s.objects,
+            ...state._.objects,
+          }
+        },
+        _: S.initial,
+      };
+    }
+    case FLUSH_CARDS: {
+      return {
+        s: {
+          ...state.s,
+          cards: {
+            ...state.s.cards,
+            ...state._.cards,
+          }
+        },
+        _: S.initial,
+      };
+
+    }
+    case FLUSH_BOXES: {
+      return {
+        s: {
+          ...state.s,
+          boxes: {
+            ...state.s.boxes,
+            ...state._.boxes,
+          }
+        },
+        _: S.initial,
+      };
+    }
+    case FLUSH_EDGES: {
+      return {
+        s: {
+          ...state.s,
+          edges: {
+            ...state.s.edges,
+            ...state._.edges,
+          }
+        },
+        _: S.initial,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};

--- a/sensemap/src/types/cached-storage.ts
+++ b/sensemap/src/types/cached-storage.ts
@@ -6,57 +6,62 @@ import { CardID, CardData, emptyCardData } from './sense/card';
 import { BoxID, BoxData, emptyBoxData } from './sense/box';
 import { EdgeID, Edge, emptyEdge } from './sense/edge';
 
+export enum TargetType {
+  PERMANENT = 'PERMANENT',
+  TEMPORARY = 'TEMPORARY',
+}
+
 /**
  * It is a storage with delayed updates.
  *
  * @todo Should model it with class-based OO?
  */
 export type CachedStorage = {
-  s: S.Storage,
-  _: S.Storage,
+  [TargetType.PERMANENT]: S.Storage,
+  [TargetType.TEMPORARY]: S.Storage,
 };
 
 export const initial = {
-  s: S.initial,
-  _: S.initial,
+  [TargetType.PERMANENT]: S.initial,
+  [TargetType.TEMPORARY]: S.initial,
 };
 
 export const toStorage = (storage: CachedStorage): S.Storage => {
   return {
     objects: {
-      ...storage.s.objects,
-      ...storage._.objects,
+      ...storage[TargetType.PERMANENT].objects,
+      ...storage[TargetType.TEMPORARY].objects,
     },
     cards: {
-      ...storage.s.cards,
-      ...storage._.cards,
+      ...storage[TargetType.PERMANENT].cards,
+      ...storage[TargetType.TEMPORARY].cards,
     },
     boxes: {
-      ...storage.s.boxes,
-      ...storage._.boxes,
+      ...storage[TargetType.PERMANENT].boxes,
+      ...storage[TargetType.TEMPORARY].boxes,
     },
     edges: {
-      ...storage.s.edges,
-      ...storage._.edges,
+      ...storage[TargetType.PERMANENT].edges,
+      ...storage[TargetType.TEMPORARY].edges,
     },
   };
 };
 
 export const getObject =
   (storage: CachedStorage, id: ObjectID): ObjectData =>
-  storage._.objects[id] || storage.s.objects[id] || emptyObjectData;
+  storage[TargetType.TEMPORARY].objects[id] || storage[TargetType.PERMANENT].objects[id] || emptyObjectData;
 
 export const getCard =
   (storage: CachedStorage, id: CardID): CardData =>
-  storage._.cards[id] || storage.s.cards[id] || emptyCardData;
+  storage[TargetType.TEMPORARY].cards[id] || storage[TargetType.PERMANENT].cards[id] || emptyCardData;
 
 export const getBox =
   (storage: CachedStorage, id: BoxID): BoxData =>
-  storage._.boxes[id] || storage.s.boxes[id] || emptyBoxData;
+  storage[TargetType.TEMPORARY].boxes[id] || storage[TargetType.PERMANENT].boxes[id] || emptyBoxData;
 
 export const getEdge =
   (storage: CachedStorage, id: EdgeID): Edge =>
-  storage._.edges[id] || storage.s.edges[id] || emptyEdge;
+  storage[TargetType.TEMPORARY].edges[id] || storage[TargetType.PERMANENT].edges[id] || emptyEdge;
 
 // XXX: duplicated
 export const getCardsInBox = (storage: CachedStorage, id: BoxID): ObjectMap<CardData> =>
@@ -66,40 +71,40 @@ export const getCardsInBox = (storage: CachedStorage, id: BoxID): ObjectMap<Card
     .reduce((a, c) => { a[c.id] = c; return a; }, {});
 
 export const doesObjectExist = (storage: CachedStorage, id: ObjectID): boolean =>
-  S.doesObjectExist(storage._, id) || S.doesObjectExist(storage.s, id);
+  S.doesObjectExist(storage[TargetType.TEMPORARY], id) || S.doesObjectExist(storage[TargetType.PERMANENT], id);
 
 export const doesCardExist = (storage: CachedStorage, id: CardID): boolean =>
-  S.doesCardExist(storage._, id) || S.doesCardExist(storage.s, id);
+  S.doesCardExist(storage[TargetType.TEMPORARY], id) || S.doesCardExist(storage[TargetType.PERMANENT], id);
 
 export const doesBoxExist = (storage: CachedStorage, id: BoxID): boolean =>
-  S.doesBoxExist(storage._, id) || S.doesBoxExist(storage.s, id);
+  S.doesBoxExist(storage[TargetType.TEMPORARY], id) || S.doesBoxExist(storage[TargetType.PERMANENT], id);
 
 export const doesEdgeExist = (storage: CachedStorage, id: EdgeID): boolean =>
-  S.doesEdgeExist(storage._, id) || S.doesEdgeExist(storage.s, id);
+  S.doesEdgeExist(storage[TargetType.TEMPORARY], id) || S.doesEdgeExist(storage[TargetType.PERMANENT], id);
 
 export const isObjectNew = (storage: CachedStorage, id: ObjectID): boolean =>
-  S.doesObjectExist(storage._, id) && !S.doesObjectExist(storage.s, id);
+  S.doesObjectExist(storage[TargetType.TEMPORARY], id) && !S.doesObjectExist(storage[TargetType.PERMANENT], id);
 
 export const isCardNew = (storage: CachedStorage, id: CardID): boolean =>
-  S.doesCardExist(storage._, id) && !S.doesCardExist(storage.s, id);
+  S.doesCardExist(storage[TargetType.TEMPORARY], id) && !S.doesCardExist(storage[TargetType.PERMANENT], id);
 
 export const isBoxNew = (storage: CachedStorage, id: BoxID): boolean =>
-  S.doesBoxExist(storage._, id) && !S.doesBoxExist(storage.s, id);
+  S.doesBoxExist(storage[TargetType.TEMPORARY], id) && !S.doesBoxExist(storage[TargetType.PERMANENT], id);
 
 export const isEdgeNew = (storage: CachedStorage, id: EdgeID): boolean =>
-  S.doesEdgeExist(storage._, id) && !S.doesEdgeExist(storage.s, id);
+  S.doesEdgeExist(storage[TargetType.TEMPORARY], id) && !S.doesEdgeExist(storage[TargetType.PERMANENT], id);
 
 export const isObjectDirty = (storage: CachedStorage, id: ObjectID): boolean =>
-  S.doesObjectExist(storage._, id) && S.doesObjectExist(storage.s, id);
+  S.doesObjectExist(storage[TargetType.TEMPORARY], id) && S.doesObjectExist(storage[TargetType.PERMANENT], id);
 
 export const isCardDirty = (storage: CachedStorage, id: CardID): boolean =>
-  S.doesCardExist(storage._, id) && S.doesCardExist(storage.s, id);
+  S.doesCardExist(storage[TargetType.TEMPORARY], id) && S.doesCardExist(storage[TargetType.PERMANENT], id);
 
 export const isBoxDirty = (storage: CachedStorage, id: BoxID): boolean =>
-  S.doesBoxExist(storage._, id) && S.doesBoxExist(storage.s, id);
+  S.doesBoxExist(storage[TargetType.TEMPORARY], id) && S.doesBoxExist(storage[TargetType.PERMANENT], id);
 
 export const isEdgeDirty = (storage: CachedStorage, id: EdgeID): boolean =>
-  S.doesEdgeExist(storage._, id) && S.doesEdgeExist(storage.s, id);
+  S.doesEdgeExist(storage[TargetType.TEMPORARY], id) && S.doesEdgeExist(storage[TargetType.PERMANENT], id);
 
 export const scoped = (storage: CachedStorage, filter: (key: ObjectID) => boolean): S.Storage =>
   S.scoped(toStorage(storage), filter);
@@ -116,6 +121,78 @@ export const scopedToMap = (storage: CachedStorage): S.Storage => {
   const filter = (key: ObjectID): boolean => !getObject(storage, key).belongsTo;
   return scoped(storage, filter);
 };
+
+const updateObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.UPDATE_OBJECTS as typeof S.UPDATE_OBJECTS,
+  payload: { objects, target },
+});
+
+const overwriteObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.OVERWRITE_OBJECTS as typeof S.OVERWRITE_OBJECTS,
+  payload: { objects, target },
+});
+
+const removeObjects = (objects: ObjectMap<ObjectData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.REMOVE_OBJECTS as typeof S.REMOVE_OBJECTS,
+  payload: { objects, target },
+});
+
+const updateCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.UPDATE_CARDS as typeof S.UPDATE_CARDS,
+  payload: { cards, target },
+});
+
+const overwriteCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.OVERWRITE_CARDS as typeof S.OVERWRITE_CARDS,
+  payload: { cards, target },
+});
+
+const removeCards = (cards: ObjectMap<CardData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.REMOVE_CARDS as typeof S.REMOVE_CARDS,
+  payload: { cards, target },
+});
+
+const updateBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.UPDATE_BOXES as typeof S.UPDATE_BOXES,
+  payload: { boxes, target },
+});
+
+const overwriteBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.OVERWRITE_BOXES as typeof S.OVERWRITE_BOXES,
+  payload: { boxes, target },
+});
+
+const removeBoxes = (boxes: ObjectMap<BoxData>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.REMOVE_BOXES as typeof S.REMOVE_BOXES,
+  payload: { boxes, target },
+});
+
+const updateEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.UPDATE_EDGES as typeof S.UPDATE_EDGES,
+  payload: { edges, target },
+});
+
+const overwriteEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.OVERWRITE_EDGES as typeof S.OVERWRITE_EDGES,
+  payload: { edges, target },
+});
+
+const removeEdges = (edges: ObjectMap<Edge>, target: TargetType = TargetType.TEMPORARY) => ({
+  type: S.REMOVE_EDGES as typeof S.REMOVE_EDGES,
+  payload: { edges, target },
+});
+
+export const updateNotInBox =
+  (cardObject: ObjectID, box: BoxID, target: TargetType = TargetType.TEMPORARY) => ({
+    type: S.UPDATE_NOT_IN_BOX as typeof S.UPDATE_NOT_IN_BOX,
+    payload: { cardObject, box, target },
+  });
+
+export const updateInBox =
+  (cardObject: ObjectID, box: BoxID, target: TargetType = TargetType.TEMPORARY) => ({
+    type: S.UPDATE_IN_BOX as typeof S.UPDATE_IN_BOX,
+    payload: { cardObject, box, target },
+  });
 
 const FLUSH = 'FLUSH';
 const flush = () => ({
@@ -143,7 +220,20 @@ const flushEdges = () => ({
 });
 
 export const actions = {
-  ...S.actions,
+  updateObjects,
+  overwriteObjects,
+  removeObjects,
+  updateCards,
+  overwriteCards,
+  removeCards,
+  updateBoxes,
+  overwriteBoxes,
+  removeBoxes,
+  updateEdges,
+  overwriteEdges,
+  removeEdges,
+  updateInBox,
+  updateNotInBox,
   flush,
   flushObjects,
   flushCards,
@@ -169,64 +259,66 @@ export const reducer = (state: CachedStorage = initial, action: Action = emptyAc
     case S.REMOVE_EDGES:
     case S.UPDATE_NOT_IN_BOX:
     case S.UPDATE_IN_BOX: {
+      const { target } = action.payload;
+
       return {
-        s: state.s,
-        _: S.reducer(state._, action),
+        ...state,
+        [target]: S.reducer(state[target], action),
       };
     }
     case FLUSH: {
       return {
-        s: toStorage(state),
-        _: S.initial,
+        [TargetType.PERMANENT]: toStorage(state),
+        [TargetType.TEMPORARY]: S.initial,
       };
     }
     case FLUSH_OBJECTS: {
       return {
-        s: {
-          ...state.s,
+        [TargetType.PERMANENT]: {
+          ...state[TargetType.PERMANENT],
           objects: {
-            ...state.s.objects,
-            ...state._.objects,
+            ...state[TargetType.PERMANENT].objects,
+            ...state[TargetType.TEMPORARY].objects,
           }
         },
-        _: S.initial,
+        [TargetType.TEMPORARY]: S.initial,
       };
     }
     case FLUSH_CARDS: {
       return {
-        s: {
-          ...state.s,
+        [TargetType.PERMANENT]: {
+          ...state[TargetType.PERMANENT],
           cards: {
-            ...state.s.cards,
-            ...state._.cards,
+            ...state[TargetType.PERMANENT].cards,
+            ...state[TargetType.TEMPORARY].cards,
           }
         },
-        _: S.initial,
+        [TargetType.TEMPORARY]: S.initial,
       };
 
     }
     case FLUSH_BOXES: {
       return {
-        s: {
-          ...state.s,
+        [TargetType.PERMANENT]: {
+          ...state[TargetType.PERMANENT],
           boxes: {
-            ...state.s.boxes,
-            ...state._.boxes,
+            ...state[TargetType.PERMANENT].boxes,
+            ...state[TargetType.TEMPORARY].boxes,
           }
         },
-        _: S.initial,
+        [TargetType.TEMPORARY]: S.initial,
       };
     }
     case FLUSH_EDGES: {
       return {
-        s: {
-          ...state.s,
+        [TargetType.PERMANENT]: {
+          ...state[TargetType.PERMANENT],
           edges: {
-            ...state.s.edges,
-            ...state._.edges,
+            ...state[TargetType.PERMANENT].edges,
+            ...state[TargetType.TEMPORARY].edges,
           }
         },
-        _: S.initial,
+        [TargetType.TEMPORARY]: S.initial,
       };
     }
     default: {

--- a/sensemap/src/types/object-editor.ts
+++ b/sensemap/src/types/object-editor.ts
@@ -132,10 +132,10 @@ export const reducer = (state: State = initial, action: Action = emptyAction) =>
       let { temp } = state;
       switch (objectType) {
         case ObjectType.BOX:
-          temp = SO.reducer(temp, SO.actions.updateBoxes(HasID.toIDMap<BoxID, BoxData>([data as BoxData])));
+          temp = SO.reducer(temp, S.actions.updateBoxes(HasID.toIDMap<BoxID, BoxData>([data as BoxData])));
           break;
         case ObjectType.CARD:
-          temp = SO.reducer(temp, SO.actions.updateCards(HasID.toIDMap<CardID, CardData>([data as CardData])));
+          temp = SO.reducer(temp, S.actions.updateCards(HasID.toIDMap<CardID, CardData>([data as CardData])));
           break;
         default:
       }

--- a/sensemap/src/types/object-editor.ts
+++ b/sensemap/src/types/object-editor.ts
@@ -6,6 +6,7 @@ import { BoxID, BoxData, Action as BoxAction, emptyBoxData, reducer as boxReduce
 import { CardID, CardData, Action as CardAction, emptyCardData, reducer as cardReducer } from './sense/card';
 import * as F from './sense/focus';
 import * as SO from './sense-object';
+import * as S from './storage';
 import { clone } from 'ramda';
 
 export enum StatusType {
@@ -52,10 +53,10 @@ const updateCard =
   (id: CardID, action: CardAction) =>
   (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
-    let card = SO.getCard(state.editor.temp, id);
+    let card = S.getCard(state.editor.temp, id);
 
     if (card.id === emptyCardData.id) {
-      card = SO.getCard(state.senseObject, id);
+      card = S.getCard(state.senseObject, id);
       dispatch(snapshotObject(ObjectType.CARD, card));
     }
 
@@ -73,10 +74,10 @@ const updateBox =
   (id: BoxID, action: BoxAction) =>
   (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
-    let box = SO.getBox(state.editor.temp, id);
+    let box = S.getBox(state.editor.temp, id);
 
     if (box.id === emptyBoxData.id) {
-      box = SO.getBox(state.senseObject, id);
+      box = S.getBox(state.senseObject, id);
       dispatch(snapshotObject(ObjectType.BOX, box));
     }
 
@@ -102,13 +103,13 @@ export type Action = ActionUnion<typeof syncActions>;
 
 export type State = {
   status: StatusType,
-  temp: SO.State,
+  temp: S.Storage,
   focus: F.Focus,
 };
 
 export const initial: State = {
   status: StatusType.HIDE,
-  temp: SO.reducer(),
+  temp: S.initial, // S.reducer()
   focus: F.focusNothing(),
 };
 
@@ -116,8 +117,8 @@ export const getFocusedObject = (state: State): CardData | BoxData | null => {
   const { focus } = state;
 
   switch (focus.objectType) {
-    case ObjectType.BOX:  return SO.getBox(state.temp, focus.data);
-    case ObjectType.CARD: return SO.getCard(state.temp, focus.data);
+    case ObjectType.BOX:  return S.getBox(state.temp, focus.data);
+    case ObjectType.CARD: return S.getCard(state.temp, focus.data);
     default:              return null;
   }
 };
@@ -177,7 +178,7 @@ export const reducer = (state: State = initial, action: Action = emptyAction) =>
           ...temp,
           cards: {
             ...temp.cards,
-            [id]: cardReducer(SO.getCard(temp, id), act)
+            [id]: cardReducer(S.getCard(temp, id), act)
           }
         }
       };
@@ -192,7 +193,7 @@ export const reducer = (state: State = initial, action: Action = emptyAction) =>
           ...temp,
           boxes: {
             ...temp.boxes,
-            [id]: boxReducer(SO.getBox(temp, id), act)
+            [id]: boxReducer(S.getBox(temp, id), act)
           }
         }
       };

--- a/sensemap/src/types/object-editor.ts
+++ b/sensemap/src/types/object-editor.ts
@@ -1,32 +1,10 @@
-import { Dispatch, GetState } from '.';
 import { ActionUnion, emptyAction } from './action';
-import * as HasID from './sense/has-id';
-import { ObjectType } from './sense/object';
-import { BoxID, BoxData, Action as BoxAction, emptyBoxData, reducer as boxReducer } from './sense/box';
-import { CardID, CardData, Action as CardAction, emptyCardData, reducer as cardReducer } from './sense/card';
 import * as F from './sense/focus';
-import * as SO from './sense-object';
-import * as S from './storage';
-import { clone } from 'ramda';
 
 export enum StatusType {
   HIDE = 'SIDEBAR_HIDE',
   SHOW = 'SIDEBAR_SHOW',
 }
-
-const SNAPSHOT_OBJECT = 'SNAPSHOT_OBJECT';
-const snapshotObject =
-  (objectType: ObjectType, data: CardData | BoxData) => ({
-    type: SNAPSHOT_OBJECT as typeof SNAPSHOT_OBJECT,
-    payload: { objectType, data },
-  });
-
-const CLEAR_OBJECT = 'CLEAR_OBJECT';
-const clearObject =
-  (objectType: ObjectType, id: CardID | BoxID) => ({
-    type: CLEAR_OBJECT as typeof CLEAR_OBJECT,
-    payload: { objectType, id },
-  });
 
 const CHANGE_STATUS = 'CHANGE_STATUS';
 const changeStatus =
@@ -42,122 +20,25 @@ const focusObject =
     payload: { focus },
   });
 
-const UPDATE_EDITOR_CARD = 'UPDATE_EDITOR_CARD';
-const updateEditorCard =
-  (id: CardID, action: CardAction) => ({
-    type: UPDATE_EDITOR_CARD as typeof UPDATE_EDITOR_CARD,
-    payload: { id, action },
-  });
-
-const updateCard =
-  (id: CardID, action: CardAction) =>
-  (dispatch: Dispatch, getState: GetState) => {
-    const state = getState();
-    let card = S.getCard(state.editor.temp, id);
-
-    if (card.id === emptyCardData.id) {
-      card = S.getCard(state.senseObject, id);
-      dispatch(snapshotObject(ObjectType.CARD, card));
-    }
-
-    return Promise.resolve(dispatch(updateEditorCard(id, action)));
-  };
-
-const UPDATE_EDITOR_BOX = 'UPDATE_EDITOR_BOX';
-const updateEditorBox =
-  (id: BoxID, action: BoxAction) => ({
-    type: UPDATE_EDITOR_BOX as typeof UPDATE_EDITOR_BOX,
-    payload: { id, action },
-  });
-
-const updateBox =
-  (id: BoxID, action: BoxAction) =>
-  (dispatch: Dispatch, getState: GetState) => {
-    const state = getState();
-    let box = S.getBox(state.editor.temp, id);
-
-    if (box.id === emptyBoxData.id) {
-      box = S.getBox(state.senseObject, id);
-      dispatch(snapshotObject(ObjectType.BOX, box));
-    }
-
-    return Promise.resolve(dispatch(updateEditorBox(id, action)));
-  };
-
-export const syncActions = {
-  snapshotObject,
-  clearObject,
+export const actions = {
   changeStatus,
   focusObject,
-  updateEditorCard,
-  updateEditorBox,
 };
 
-export const actions = {
-  ...syncActions,
-  updateCard,
-  updateBox,
-};
-
-export type Action = ActionUnion<typeof syncActions>;
+export type Action = ActionUnion<typeof actions>;
 
 export type State = {
   status: StatusType,
-  temp: S.Storage,
   focus: F.Focus,
 };
 
 export const initial: State = {
   status: StatusType.HIDE,
-  temp: S.initial, // S.reducer()
   focus: F.focusNothing(),
-};
-
-export const getFocusedObject = (state: State): CardData | BoxData | null => {
-  const { focus } = state;
-
-  switch (focus.objectType) {
-    case ObjectType.BOX:  return S.getBox(state.temp, focus.data);
-    case ObjectType.CARD: return S.getCard(state.temp, focus.data);
-    default:              return null;
-  }
 };
 
 export const reducer = (state: State = initial, action: Action = emptyAction) => {
   switch (action.type) {
-    case SNAPSHOT_OBJECT: {
-      const { objectType, data } = action.payload;
-
-      // use the sense-object reducer to update our object map
-      let { temp } = state;
-      switch (objectType) {
-        case ObjectType.BOX:
-          temp = SO.reducer(temp, S.actions.updateBoxes(HasID.toIDMap<BoxID, BoxData>([data as BoxData])));
-          break;
-        case ObjectType.CARD:
-          temp = SO.reducer(temp, S.actions.updateCards(HasID.toIDMap<CardID, CardData>([data as CardData])));
-          break;
-        default:
-      }
-
-      return { ...state, temp };
-    }
-    case CLEAR_OBJECT: {
-      const { objectType, id } = action.payload;
-
-      let temp = clone(state.temp);
-      switch (objectType) {
-        case ObjectType.BOX:
-          delete temp.boxes[id];
-          break;
-        case ObjectType.CARD:
-          delete temp.cards[id];
-          break;
-        default:
-      }
-
-      return { ...state, temp };
-    }
     case CHANGE_STATUS: {
       const { status } = action.payload;
 
@@ -167,36 +48,6 @@ export const reducer = (state: State = initial, action: Action = emptyAction) =>
       const { focus } = action.payload;
 
       return { ...state, focus };
-    }
-    case UPDATE_EDITOR_CARD: {
-      const { id, action: act } = action.payload;
-      const { temp } = state;
-
-      return {
-        ...state,
-        temp: {
-          ...temp,
-          cards: {
-            ...temp.cards,
-            [id]: cardReducer(S.getCard(temp, id), act)
-          }
-        }
-      };
-    }
-    case UPDATE_EDITOR_BOX: {
-      const { id, action: act } = action.payload;
-      const { temp } = state;
-
-      return {
-        ...state,
-        temp: {
-          ...temp,
-          boxes: {
-            ...temp.boxes,
-            [id]: boxReducer(S.getBox(temp, id), act)
-          }
-        }
-      };
     }
     default:
       return state;

--- a/sensemap/src/types/redux.ts
+++ b/sensemap/src/types/redux.ts
@@ -1,6 +1,7 @@
 import { Dispatch as ReduxDispatch, Reducer as ReduxReducer, combineReducers } from 'redux';
 import { emptyAction } from './action';
 import * as SM from './sense-map';
+import * as CS from './cached-storage';
 import * as SO from './sense-object';
 import * as SL from './selection';
 import * as OE from './object-editor';
@@ -44,6 +45,7 @@ export const initial = {
 export type Action
   = typeof emptyAction
   | SM.Action
+  | CS.Action
   | SO.Action
   | SL.Action
   | OE.Action
@@ -54,14 +56,16 @@ export type Action
   ;
 
 export const actions = {
-  senseMap:    SM.actions,
-  senseObject: SO.actions,
-  selection:   SL.actions,
-  editor:      OE.actions,
-  input:        I.actions,
-  viewport:     V.actions,
-  stage:       SG.actions,
-  importer:    IP.actions,
+  senseMap:      SM.actions,
+  // senseObject also handles cachedStorage actions
+  cachedStorage: CS.actions,
+  senseObject:   SO.actions,
+  selection:     SL.actions,
+  editor:        OE.actions,
+  input:          I.actions,
+  viewport:       V.actions,
+  stage:         SG.actions,
+  importer:      IP.actions,
 };
 
 export type ActionProps = { actions: typeof actions };

--- a/sensemap/src/types/sense-map.ts
+++ b/sensemap/src/types/sense-map.ts
@@ -28,7 +28,7 @@ type BoxScope = {
 /**
  * It describes how deep we are in a sense map.
  */
-type MapScope
+export type MapScope
   = FullMapScope
   | BoxScope;
 

--- a/sensemap/src/types/sense-object.ts
+++ b/sensemap/src/types/sense-object.ts
@@ -32,7 +32,7 @@ const createCard =
       ]))));
   };
 
-const updateRemoteCard =
+const updateCard =
   (card: CardData) =>
   (dispatch: Dispatch) => {
     return GC.update(card)
@@ -50,7 +50,7 @@ const createBox =
       ]))));
   };
 
-const updateRemoteBox =
+const updateBox =
   (box: BoxData) =>
   (dispatch: Dispatch) => {
     return GB.update(box)
@@ -121,7 +121,7 @@ const createBoxObject =
   (mapId: MapID, box: BoxData) =>
   async (dispatch: Dispatch, getState: GetState) => {
     const action = await createBox(mapId, box)(dispatch);
-    const { id = '' } = Object.values(action.payload)[0] || {};
+    const { id = '' } = Object.values(action.payload.boxes)[0] || {};
     const { viewport: { width, height, top, left } } = getState();
     const x = left + (width - B.DEFAULT_WIDTH) / 2;
     const y = top + (height - B.DEFAULT_HEIGHT) / 2;
@@ -149,7 +149,7 @@ const createObjectForCard =
         data: cardId,
       })
     )(dispatch);
-    const { id = '' } = Object.values(action.payload)[0] || {};
+    const { id = '' } = Object.values(action.payload.objects)[0] || {};
     if (box) {
       addCardToBox(id, box)(dispatch);
     }
@@ -160,7 +160,7 @@ const createCardObject =
   (mapId: MapID, card: CardData) =>
   async (dispatch: Dispatch, getState: GetState) => {
     const action = await createCard(mapId, card)(dispatch);
-    const { id = '' } = Object.values(action.payload)[0] || {};
+    const { id = '' } = Object.values(action.payload.cards)[0] || {};
     return createObjectForCard(mapId, id)(dispatch, getState);
   };
 
@@ -200,7 +200,7 @@ const removeCardsFromBox =
     return dispatch(SL.actions.clearSelection());
   };
 
-const deleteObject =
+const removeObject =
   (objectID: ObjectID) =>
   (dispatch: Dispatch, getState: GetState) => {
     const { senseMap: { map } } = getState();
@@ -211,7 +211,7 @@ const deleteObject =
       .then(() => loadBoxes(map, true)(dispatch));
   };
 
-const deleteCard =
+const removeCard =
   (cardID: CardID) =>
   (dispatch: Dispatch, getState: GetState) => {
     const { senseMap: { map } } = getState();
@@ -221,14 +221,14 @@ const deleteCard =
       .then(() => loadObjects(map, true)(dispatch));
   };
 
-const deleteCardWithObject =
+const removeCardWithObject =
   (cardID: CardID) =>
   (dispatch: Dispatch, getState: GetState) => {
     return G.deleteObjectsByCard(cardID)
-      .then(() => deleteCard(cardID)(dispatch, getState));
+      .then(() => removeCard(cardID)(dispatch, getState));
   };
 
-const deleteBox =
+const removeBox =
   (boxID: BoxID) =>
   (dispatch: Dispatch, getState: GetState) => {
     const { senseMap: { map } } = getState();
@@ -238,17 +238,17 @@ const deleteBox =
       .then(() => loadObjects(map, true)(dispatch));
   };
 
-const deleteBoxWithObject =
+const removeBoxWithObject =
   (boxID: BoxID) =>
   (dispatch: Dispatch, getState: GetState) => {
     return G.deleteObjectsByBox(boxID)
-      .then(() => deleteBox(boxID)(dispatch, getState));
+      .then(() => removeBox(boxID)(dispatch, getState));
   };
 
 const unboxCards =
   (boxID: BoxID) =>
   (dispatch: Dispatch, getState: GetState) => {
-    return deleteBoxWithObject(boxID)(dispatch, getState)
+    return removeBoxWithObject(boxID)(dispatch, getState)
       .then(() => dispatch(SM.actions.setScopeToFullmap()));
   };
 
@@ -259,7 +259,7 @@ const createEdge =
       .then((edge) => dispatch(S.updateEdges(H.toIDMap<EdgeID, Edge>([ edge ]))));
   };
 
-const deleteEdge =
+const removeEdge =
   (map: MapID, edge: EdgeID) =>
   (dispatch: Dispatch, getState: GetState) => {
     return GE.remove(edge)
@@ -267,8 +267,8 @@ const deleteEdge =
   };
 
 export const actions = {
-  updateRemoteCard,
-  updateRemoteBox,
+  updateCard,
+  updateBox,
   loadObjects,
   loadCards,
   loadBoxes,
@@ -284,10 +284,10 @@ export const actions = {
   removeCardFromBox,
   removeCardsFromBox,
   unboxCards,
-  deleteObject,
-  deleteCardWithObject,
-  deleteBoxWithObject,
-  deleteEdge,
+  removeObject,
+  removeCardWithObject,
+  removeBoxWithObject,
+  removeEdge,
 };
 
 export type Action = S.Action;

--- a/sensemap/src/types/sense-object.ts
+++ b/sensemap/src/types/sense-object.ts
@@ -9,7 +9,6 @@ import * as C from './sense/card';
 import { CardID, CardData } from './sense/card';
 import * as B from './sense/box';
 import { BoxID, BoxData } from './sense/box';
-import * as O from './sense/object';
 import { ObjectType, ObjectID, ObjectData, objectData } from './sense/object';
 import { Edge, EdgeID } from './sense/edge';
 import * as CS from './cached-storage';
@@ -210,17 +209,9 @@ const createCardObject =
 
 const moveObject =
   (id: ObjectID, x: number, y: number) =>
-  (dispatch: Dispatch, getState: GetState) => {
-    const { senseObject } = getState();
-    // compute the local object position
-    const o = O.reducer(CS.getObject(senseObject, id), O.updatePosition(x, y));
-    return Promise.resolve(o)
-      // optimistic update
-      .then((object) => dispatch(CS.updateObjects(H.toIDMap<ObjectID, ObjectData>([
-        object
-      ]))))
-      // update the remote object
-      .then(() => GO.move(id, x, y))
+  (dispatch: Dispatch) => {
+    // update the remote object
+    return GO.move(id, x, y)
       // sync the local object
       .then((object) => {
         const objectMap = H.toIDMap<ObjectID, ObjectData>([object]);

--- a/sensemap/src/types/sense-object.ts
+++ b/sensemap/src/types/sense-object.ts
@@ -15,7 +15,7 @@ import { Edge, EdgeID } from './sense/edge';
 import * as S from './storage';
 import { Storage } from './storage';
 import { MapID } from './sense-map';
-import { ActionUnion, emptyAction } from './action';
+import { emptyAction } from './action';
 import * as SL from './selection';
 import * as SM from './sense-map';
 
@@ -23,96 +23,11 @@ export type State = Storage;
 
 export const initial: State = S.initial;
 
-/**
- * Partially update `objects` state.
- */
-const UPDATE_OBJECTS = 'UPDATE_OBJECTS';
-const updateObjects =
-  (objects: { [key: string]: ObjectData }) => ({
-    type: UPDATE_OBJECTS as typeof UPDATE_OBJECTS,
-    payload: objects,
-  });
-
-const OVERWRITE_OBJECTS = 'OVERWRITE_OBJECTS';
-const overwriteObjects =
-  (objects: { [key: string]: ObjectData }) => ({
-    type: OVERWRITE_OBJECTS as typeof OVERWRITE_OBJECTS,
-    payload: objects,
-  });
-
-/**
- * Partially update `cards` state.
- */
-const UPDATE_CARDS = 'UPDATE_CARDS';
-const updateCards =
-  (cards: State['cards']) => ({
-    type: UPDATE_CARDS as typeof UPDATE_CARDS,
-    payload: cards,
-  });
-
-const OVERWRITE_CARDS = 'OVERWRITE_CARDS';
-const overwriteCards =
-  (cards: State['cards']) => ({
-    type: OVERWRITE_CARDS as typeof OVERWRITE_CARDS,
-    payload: cards,
-  });
-
-/**
- * Partially update `boxes` state.
- */
-const UPDATE_BOXES = 'UPDATE_BOXES';
-const updateBoxes =
-  (boxes: State['boxes']) => ({
-    type: UPDATE_BOXES as typeof UPDATE_BOXES,
-    payload: boxes,
-  });
-
-const OVERWRITE_BOXES = 'OVERWRITE_BOXES';
-const overwriteBoxes =
-  (boxes: State['boxes']) => ({
-    type: OVERWRITE_BOXES as typeof OVERWRITE_BOXES,
-    payload: boxes,
-  });
-
-const UPDATE_EDGES = 'UPDATE_EDGES';
-const updateEdges =
-  (edges: State['edges']) => ({
-    type: UPDATE_EDGES as typeof UPDATE_EDGES,
-    payload: edges,
-  });
-
-const OVERWRITE_EDGES = 'OVERWRITE_EDGES';
-const overwriteEdges =
-  (edges: State['edges']) => ({
-    type: OVERWRITE_EDGES as typeof OVERWRITE_EDGES,
-    payload: edges,
-  });
-
-/**
- * Remove card from Box.contains bidirectional relation.
- */
-const UPDATE_NOT_IN_BOX = 'UPDATE_NOT_IN_BOX';
-const updateNotInBox =
-  (cardObject: ObjectID, box: BoxID) => ({
-    type: UPDATE_NOT_IN_BOX as typeof UPDATE_NOT_IN_BOX,
-    payload: { cardObject, box }
-  });
-
-/**
- * Add card to Box.contains bidirectional relation.
- */
-const UPDATE_IN_BOX = 'UPDATE_IN_BOX';
-const updateInBox =
-  (cardObject: ObjectID, box: BoxID) => ({
-    type: UPDATE_IN_BOX as typeof UPDATE_IN_BOX,
-    payload: { cardObject, box }
-  });
-
 const createCard =
   (mapId: MapID, card: CardData) =>
   async (dispatch: Dispatch) => {
     return GC.create(mapId, card)
-      .then((newCard) => dispatch(updateCards(H.toIDMap<CardID, CardData>([
+      .then((newCard) => dispatch(S.updateCards(H.toIDMap<CardID, CardData>([
         newCard
       ]))));
   };
@@ -121,7 +36,7 @@ const updateRemoteCard =
   (card: CardData) =>
   (dispatch: Dispatch) => {
     return GC.update(card)
-      .then((newCard) => dispatch(updateCards(H.toIDMap<CardID, CardData>([
+      .then((newCard) => dispatch(S.updateCards(H.toIDMap<CardID, CardData>([
         newCard
       ]))));
   };
@@ -130,7 +45,7 @@ const createBox =
   (mapId: MapID, box: BoxData) =>
   async (dispatch: Dispatch) => {
     return GB.create(mapId, box)
-      .then((newBox) => dispatch(updateBoxes(H.toIDMap<BoxID, BoxData>([
+      .then((newBox) => dispatch(S.updateBoxes(H.toIDMap<BoxID, BoxData>([
         newBox
       ]))));
   };
@@ -139,7 +54,7 @@ const updateRemoteBox =
   (box: BoxData) =>
   (dispatch: Dispatch) => {
     return GB.update(box)
-      .then((newBox) => dispatch(updateBoxes(H.toIDMap<BoxID, BoxData>([
+      .then((newBox) => dispatch(S.updateBoxes(H.toIDMap<BoxID, BoxData>([
         newBox
       ]))));
   };
@@ -149,7 +64,7 @@ const loadObjects =
   (dispatch: Dispatch) => {
     return GO.loadObjects(id)
       .then(data => H.toIDMap<ObjectID, ObjectData>(data))
-      .then(data => dispatch(overwrite ? overwriteObjects(data) : updateObjects(data)));
+      .then(data => dispatch(overwrite ? S.overwriteObjects(data) : S.updateObjects(data)));
   };
 
 const loadCards =
@@ -157,7 +72,7 @@ const loadCards =
   (dispatch: Dispatch) => {
     return GC.loadCards(id)
       .then(data => H.toIDMap<CardID, CardData>(data))
-      .then(data => dispatch(overwrite ? overwriteCards(data) : updateCards(data)));
+      .then(data => dispatch(overwrite ? S.overwriteCards(data) : S.updateCards(data)));
   };
 
 const loadBoxes =
@@ -165,7 +80,7 @@ const loadBoxes =
   (dispatch: Dispatch) => {
     return GB.loadBoxes(id)
       .then(data => H.toIDMap<BoxID, BoxData>(data))
-      .then(data => dispatch(overwrite ? overwriteBoxes(data) : updateBoxes(data)));
+      .then(data => dispatch(overwrite ? S.overwriteBoxes(data) : S.updateBoxes(data)));
   };
 
 const loadEdges =
@@ -173,14 +88,14 @@ const loadEdges =
   (dispatch: Dispatch) => {
     return GE.load(id)
       .then(data => H.toIDMap<EdgeID, Edge>(data))
-      .then(data => dispatch(overwrite ? overwriteEdges(data) : updateEdges(data)));
+      .then(data => dispatch(overwrite ? S.overwriteEdges(data) : S.updateEdges(data)));
   };
 
 const addCardToBox =
   (cardObject: ObjectID, box: BoxID) =>
   (dispatch: Dispatch) => {
     return G.addCardToBox(cardObject, box)
-      .then(() => dispatch(updateInBox(cardObject, box)))
+      .then(() => dispatch(S.updateInBox(cardObject, box)))
       .then(() => dispatch(SL.actions.clearSelection()));
   };
 
@@ -197,7 +112,7 @@ const createObject =
   (mapId: MapID, data: ObjectData) =>
   (dispatch: Dispatch) => {
     return GO.create(mapId, data)
-      .then((object) => dispatch(updateObjects(H.toIDMap<ObjectID, ObjectData>([
+      .then((object) => dispatch(S.updateObjects(H.toIDMap<ObjectID, ObjectData>([
         object
       ]))));
   };
@@ -257,13 +172,13 @@ const moveObject =
     const o = O.reducer(S.getObject(senseObject, id), O.updatePosition(x, y));
     return Promise.resolve(o)
       // optimistic update
-      .then((object) => dispatch(updateObjects(H.toIDMap<ObjectID, ObjectData>([
+      .then((object) => dispatch(S.updateObjects(H.toIDMap<ObjectID, ObjectData>([
         object
       ]))))
       // update the remote object
       .then(() => GO.move(id, x, y))
       // sync the local object
-      .then((object) => dispatch(updateObjects(H.toIDMap<ObjectID, ObjectData>([
+      .then((object) => dispatch(S.updateObjects(H.toIDMap<ObjectID, ObjectData>([
         object
       ]))));
   };
@@ -272,7 +187,7 @@ const removeCardFromBox =
   (cardObject: ObjectID, box: BoxID) =>
   (dispatch: Dispatch) => {
     return G.removeCardFromBox(cardObject, box)
-      .then(() => dispatch(updateNotInBox(cardObject, box)))
+      .then(() => dispatch(S.updateNotInBox(cardObject, box)))
       .then(() => dispatch(SL.actions.clearSelection()));
   };
 
@@ -341,7 +256,7 @@ const createEdge =
   (map: MapID, from: ObjectID, to: ObjectID) =>
   (dispatch: Dispatch, getState: GetState) => {
     return GE.create(map, from, to)
-      .then((edge) => dispatch(updateEdges(H.toIDMap<EdgeID, Edge>([ edge ]))));
+      .then((edge) => dispatch(S.updateEdges(H.toIDMap<EdgeID, Edge>([ edge ]))));
   };
 
 const deleteEdge =
@@ -351,21 +266,7 @@ const deleteEdge =
       .then(() => loadEdges(map, true)(dispatch));
   };
 
-export const syncActions = {
-  updateObjects,
-  overwriteObjects,
-  updateCards,
-  overwriteCards,
-  updateBoxes,
-  overwriteBoxes,
-  updateEdges,
-  overwriteEdges,
-  updateNotInBox,
-  updateInBox,
-};
-
 export const actions = {
-  ...syncActions,
   updateRemoteCard,
   updateRemoteBox,
   loadObjects,
@@ -389,88 +290,21 @@ export const actions = {
   deleteEdge,
 };
 
-export type Action = ActionUnion<typeof syncActions>;
+export type Action = S.Action;
 
-export const reducer = (state: State = initial, action: Action = emptyAction): State => {
+export const reducer = (state: State = initial, action: S.Action = emptyAction): State => {
   switch (action.type) {
-    case UPDATE_OBJECTS: {
-      return {
-        ...state,
-        objects: { ...state.objects, ...action.payload },
-      };
-    }
-    case OVERWRITE_OBJECTS: {
-      return {
-        ...state,
-        objects: action.payload,
-      };
-    }
-    case UPDATE_CARDS: {
-      return {
-        ...state,
-        cards: { ...state.cards, ...action.payload },
-      };
-    }
-    case OVERWRITE_CARDS: {
-      return {
-        ...state,
-        cards: action.payload,
-      };
-    }
-    case UPDATE_BOXES: {
-      return {
-        ...state,
-        boxes: { ...state.boxes, ...action.payload },
-      };
-    }
-    case OVERWRITE_BOXES: {
-      return {
-        ...state,
-        boxes: action.payload,
-      };
-    }
-    case UPDATE_EDGES: {
-      return { ...state, edges: { ...state.edges, ...action.payload } };
-    }
-    case OVERWRITE_EDGES: {
-      return { ...state, edges: action.payload };
-    }
-    case UPDATE_NOT_IN_BOX: {
-      const box        = state.boxes[action.payload.box];
-      const cardObject = state.objects[action.payload.cardObject];
-      let { contains } = box;
-      delete(contains[cardObject.id]);
-      return {
-        ...state,
-        boxes: {
-          ...state.boxes,
-          [box.id]: { ...box, contains },
-        },
-        objects: {
-          ...state.objects,
-          [cardObject.id]: { ...cardObject, belongsTo: undefined },
-        }
-      };
-    }
-    case UPDATE_IN_BOX: {
-      const box        = state.boxes[action.payload.box];
-      const cardObject = state.objects[action.payload.cardObject];
-      const contains   = {
-        ...box.contains,
-        [cardObject.id]: { id: cardObject.id },
-      };
-      return {
-        ...state,
-        boxes: {
-          ...state.boxes,
-          [box.id]: { ...box, contains },
-        },
-        objects: {
-          ...state.objects,
-          [cardObject.id]: { ...cardObject, belongsTo: box.id },
-        },
-      };
-    }
+    case S.UPDATE_OBJECTS:
+    case S.OVERWRITE_OBJECTS:
+    case S.UPDATE_CARDS:
+    case S.OVERWRITE_CARDS:
+    case S.UPDATE_BOXES:
+    case S.OVERWRITE_BOXES:
+    case S.UPDATE_EDGES:
+    case S.OVERWRITE_EDGES:
+    case S.UPDATE_NOT_IN_BOX:
+    case S.UPDATE_IN_BOX:
+      return S.reducer(state, action);
     default: {
       return state;
     }

--- a/sensemap/src/types/sense/has-id.ts
+++ b/sensemap/src/types/sense/has-id.ts
@@ -7,6 +7,8 @@ export interface HasID<T> {
 
 /**
  * ObjectMap indexes objects by strings.
+ *
+ * @todo Move to another file.
  */
 export interface ObjectMap<T> {
   [key: string]: T;

--- a/sensemap/src/types/sense/has-id.ts
+++ b/sensemap/src/types/sense/has-id.ts
@@ -6,6 +6,13 @@ export interface HasID<T> {
 }
 
 /**
+ * ObjectMap indexes objects by strings.
+ */
+export interface ObjectMap<T> {
+  [key: string]: T;
+}
+
+/**
  * idOrUndefined returns the id or undefined of an object.
  * @param {HasID<T>} o The object.
  */
@@ -34,6 +41,6 @@ export const idOrError: <T>(err: string, o?: HasID<T>) => T =
  * toIDMap transforms an object list into an object map.
  * @param {HasID<T>} objects The object list.
  */
-export function toIDMap<T extends string, U extends HasID<T>>(this: void, objects: U[]): { [key: string]: U } {
+export function toIDMap<T extends string, U extends HasID<T>>(this: void, objects: U[]): ObjectMap<U> {
   return objects.reduce((acc, o) => { acc[o.id as string] = o; return acc; }, {});
 }

--- a/sensemap/src/types/storage.ts
+++ b/sensemap/src/types/storage.ts
@@ -1,3 +1,4 @@
+import { ActionUnion, emptyAction } from './action';
 import { ObjectMap } from './sense/has-id';
 import { ObjectID, ObjectData, emptyObjectData } from './sense/object';
 import { CardID, CardData, emptyCardData } from './sense/card';
@@ -177,4 +178,285 @@ export const scopedToBox = (storage: Storage, id: BoxID): Storage => {
 export const scopedToMap = (storage: Storage): Storage => {
   const filter = (key: ObjectID): boolean => !getObject(storage, key).belongsTo;
   return scoped(storage, filter);
+};
+
+/**
+ * Partially update `objects` state.
+ */
+export const UPDATE_OBJECTS = 'UPDATE_OBJECTS';
+export const updateObjects =
+  (objects: ObjectMap<ObjectData>) => ({
+    type: UPDATE_OBJECTS as typeof UPDATE_OBJECTS,
+    payload: objects,
+  });
+
+/**
+ * Overwrite `objects`.
+ */
+export const OVERWRITE_OBJECTS = 'OVERWRITE_OBJECTS';
+export const overwriteObjects =
+  (objects: ObjectMap<ObjectData>) => ({
+    type: OVERWRITE_OBJECTS as typeof OVERWRITE_OBJECTS,
+    payload: objects,
+  });
+
+/**
+ * Remove listed `objects`.
+ */
+export const REMOVE_OBJECTS = 'REMOVE_OBJECTS';
+export const removeObjects =
+  (objects: ObjectMap<ObjectData>) => ({
+    type: REMOVE_OBJECTS as typeof REMOVE_OBJECTS,
+    payload: objects,
+  });
+
+/**
+ * Partially update `cards` state.
+ */
+export const UPDATE_CARDS = 'UPDATE_CARDS';
+export const updateCards =
+  (cards: ObjectMap<CardData>) => ({
+    type: UPDATE_CARDS as typeof UPDATE_CARDS,
+    payload: cards,
+  });
+
+/**
+ * Overwirte `objects`.
+ */
+export const OVERWRITE_CARDS = 'OVERWRITE_CARDS';
+export const overwriteCards =
+  (cards: ObjectMap<CardData>) => ({
+    type: OVERWRITE_CARDS as typeof OVERWRITE_CARDS,
+    payload: cards,
+  });
+
+/**
+ * Remove listed `cards`.
+ */
+export const REMOVE_CARDS = 'REMOVE_CARDS';
+export const removeCards =
+  (cards: ObjectMap<CardData>) => ({
+    type: REMOVE_CARDS as typeof REMOVE_CARDS,
+    payload: cards,
+  });
+
+/**
+ * Partially update `boxes` state.
+ */
+export const UPDATE_BOXES = 'UPDATE_BOXES';
+export const updateBoxes =
+  (boxes: ObjectMap<BoxData>) => ({
+    type: UPDATE_BOXES as typeof UPDATE_BOXES,
+    payload: boxes,
+  });
+
+/**
+ * Overwrite `boxes`.
+ */
+export const OVERWRITE_BOXES = 'OVERWRITE_BOXES';
+export const overwriteBoxes =
+  (boxes: ObjectMap<BoxData>) => ({
+    type: OVERWRITE_BOXES as typeof OVERWRITE_BOXES,
+    payload: boxes,
+  });
+
+/**
+ * Remove listed `boxes`.
+ */
+export const REMOVE_BOXES = 'REMOVE_BOXES';
+export const removeBoxes =
+  (boxes: ObjectMap<BoxData>) => ({
+    type: REMOVE_BOXES as typeof REMOVE_BOXES,
+    payload: boxes,
+  });
+
+/**
+ * Partially update `edges` state.
+ */
+export const UPDATE_EDGES = 'UPDATE_EDGES';
+export const updateEdges =
+  (edges: ObjectMap<Edge>) => ({
+    type: UPDATE_EDGES as typeof UPDATE_EDGES,
+    payload: edges,
+  });
+
+/**
+ * Overwrite `edges`.
+ */
+export const OVERWRITE_EDGES = 'OVERWRITE_EDGES';
+export const overwriteEdges =
+  (edges: ObjectMap<Edge>) => ({
+    type: OVERWRITE_EDGES as typeof OVERWRITE_EDGES,
+    payload: edges,
+  });
+
+/**
+ * Remove listed `edges`.
+ */
+export const REMOVE_EDGES = 'REMOVE_EDGES';
+export const removeEdges =
+  (edges: ObjectMap<Edge>) => ({
+    type: REMOVE_EDGES as typeof REMOVE_EDGES,
+    payload: edges,
+  });
+
+/**
+ * Remove card from Box.contains bidirectional relation.
+ */
+export const UPDATE_NOT_IN_BOX = 'UPDATE_NOT_IN_BOX';
+export const updateNotInBox =
+  (cardObject: ObjectID, box: BoxID) => ({
+    type: UPDATE_NOT_IN_BOX as typeof UPDATE_NOT_IN_BOX,
+    payload: { cardObject, box }
+  });
+
+/**
+ * Add card to Box.contains bidirectional relation.
+ */
+export const UPDATE_IN_BOX = 'UPDATE_IN_BOX';
+export const updateInBox =
+  (cardObject: ObjectID, box: BoxID) => ({
+    type: UPDATE_IN_BOX as typeof UPDATE_IN_BOX,
+    payload: { cardObject, box }
+  });
+
+export const actions = {
+  updateObjects,
+  overwriteObjects,
+  removeObjects,
+  updateCards,
+  overwriteCards,
+  removeCards,
+  updateBoxes,
+  overwriteBoxes,
+  removeBoxes,
+  updateEdges,
+  overwriteEdges,
+  removeEdges,
+  updateNotInBox,
+  updateInBox,
+};
+
+export type Action = ActionUnion<typeof actions>;
+
+export const reducer = (state: Storage = initial, action: Action = emptyAction): Storage => {
+  switch (action.type) {
+    case UPDATE_OBJECTS: {
+      return {
+        ...state,
+        objects: { ...state.objects, ...action.payload },
+      };
+    }
+    case OVERWRITE_OBJECTS: {
+      return {
+        ...state,
+        objects: action.payload,
+      };
+    }
+    case REMOVE_OBJECTS: {
+      const objects = { ...state.objects };
+      Object.keys(action.payload).forEach(key => delete objects[key]);
+
+      return {
+        ...state,
+        objects,
+      };
+    }
+    case UPDATE_CARDS: {
+      return {
+        ...state,
+        cards: { ...state.cards, ...action.payload },
+      };
+    }
+    case OVERWRITE_CARDS: {
+      return {
+        ...state,
+        cards: action.payload,
+      };
+    }
+    case REMOVE_CARDS: {
+      const cards = { ...state.cards };
+      Object.keys(action.payload).forEach(key => delete cards[key]);
+
+      return {
+        ...state,
+        cards,
+      };
+    }
+    case UPDATE_BOXES: {
+      return {
+        ...state,
+        boxes: { ...state.boxes, ...action.payload },
+      };
+    }
+    case OVERWRITE_BOXES: {
+      return {
+        ...state,
+        boxes: action.payload,
+      };
+    }
+    case REMOVE_BOXES: {
+      const boxes = { ...state.boxes };
+      Object.keys(action.payload).forEach(key => delete boxes[key]);
+
+      return {
+        ...state,
+        boxes,
+      };
+    }
+    case UPDATE_EDGES: {
+      return { ...state, edges: { ...state.edges, ...action.payload } };
+    }
+    case OVERWRITE_EDGES: {
+      return { ...state, edges: action.payload };
+    }
+    case REMOVE_EDGES: {
+      const edges = { ...state.edges };
+      Object.keys(action.payload).forEach(key => delete edges[key]);
+
+      return {
+        ...state,
+        edges,
+      };
+    }
+    case UPDATE_NOT_IN_BOX: {
+      const box        = state.boxes[action.payload.box];
+      const cardObject = state.objects[action.payload.cardObject];
+      let { contains } = box;
+      delete(contains[cardObject.id]);
+      return {
+        ...state,
+        boxes: {
+          ...state.boxes,
+          [box.id]: { ...box, contains },
+        },
+        objects: {
+          ...state.objects,
+          [cardObject.id]: { ...cardObject, belongsTo: undefined },
+        }
+      };
+    }
+    case UPDATE_IN_BOX: {
+      const box        = state.boxes[action.payload.box];
+      const cardObject = state.objects[action.payload.cardObject];
+      const contains   = {
+        ...box.contains,
+        [cardObject.id]: { id: cardObject.id },
+      };
+      return {
+        ...state,
+        boxes: {
+          ...state.boxes,
+          [box.id]: { ...box, contains },
+        },
+        objects: {
+          ...state.objects,
+          [cardObject.id]: { ...cardObject, belongsTo: box.id },
+        },
+      };
+    }
+    default: {
+      return state;
+    }
+  }
 };

--- a/sensemap/src/types/storage.ts
+++ b/sensemap/src/types/storage.ts
@@ -187,7 +187,7 @@ export const UPDATE_OBJECTS = 'UPDATE_OBJECTS';
 export const updateObjects =
   (objects: ObjectMap<ObjectData>) => ({
     type: UPDATE_OBJECTS as typeof UPDATE_OBJECTS,
-    payload: objects,
+    payload: { objects },
   });
 
 /**
@@ -197,7 +197,7 @@ export const OVERWRITE_OBJECTS = 'OVERWRITE_OBJECTS';
 export const overwriteObjects =
   (objects: ObjectMap<ObjectData>) => ({
     type: OVERWRITE_OBJECTS as typeof OVERWRITE_OBJECTS,
-    payload: objects,
+    payload: { objects },
   });
 
 /**
@@ -207,7 +207,7 @@ export const REMOVE_OBJECTS = 'REMOVE_OBJECTS';
 export const removeObjects =
   (objects: ObjectMap<ObjectData>) => ({
     type: REMOVE_OBJECTS as typeof REMOVE_OBJECTS,
-    payload: objects,
+    payload: { objects },
   });
 
 /**
@@ -217,7 +217,7 @@ export const UPDATE_CARDS = 'UPDATE_CARDS';
 export const updateCards =
   (cards: ObjectMap<CardData>) => ({
     type: UPDATE_CARDS as typeof UPDATE_CARDS,
-    payload: cards,
+    payload: { cards },
   });
 
 /**
@@ -227,7 +227,7 @@ export const OVERWRITE_CARDS = 'OVERWRITE_CARDS';
 export const overwriteCards =
   (cards: ObjectMap<CardData>) => ({
     type: OVERWRITE_CARDS as typeof OVERWRITE_CARDS,
-    payload: cards,
+    payload: { cards },
   });
 
 /**
@@ -237,7 +237,7 @@ export const REMOVE_CARDS = 'REMOVE_CARDS';
 export const removeCards =
   (cards: ObjectMap<CardData>) => ({
     type: REMOVE_CARDS as typeof REMOVE_CARDS,
-    payload: cards,
+    payload: { cards },
   });
 
 /**
@@ -247,7 +247,7 @@ export const UPDATE_BOXES = 'UPDATE_BOXES';
 export const updateBoxes =
   (boxes: ObjectMap<BoxData>) => ({
     type: UPDATE_BOXES as typeof UPDATE_BOXES,
-    payload: boxes,
+    payload: { boxes },
   });
 
 /**
@@ -257,7 +257,7 @@ export const OVERWRITE_BOXES = 'OVERWRITE_BOXES';
 export const overwriteBoxes =
   (boxes: ObjectMap<BoxData>) => ({
     type: OVERWRITE_BOXES as typeof OVERWRITE_BOXES,
-    payload: boxes,
+    payload: { boxes },
   });
 
 /**
@@ -267,7 +267,7 @@ export const REMOVE_BOXES = 'REMOVE_BOXES';
 export const removeBoxes =
   (boxes: ObjectMap<BoxData>) => ({
     type: REMOVE_BOXES as typeof REMOVE_BOXES,
-    payload: boxes,
+    payload: { boxes },
   });
 
 /**
@@ -277,7 +277,7 @@ export const UPDATE_EDGES = 'UPDATE_EDGES';
 export const updateEdges =
   (edges: ObjectMap<Edge>) => ({
     type: UPDATE_EDGES as typeof UPDATE_EDGES,
-    payload: edges,
+    payload: { edges },
   });
 
 /**
@@ -287,7 +287,7 @@ export const OVERWRITE_EDGES = 'OVERWRITE_EDGES';
 export const overwriteEdges =
   (edges: ObjectMap<Edge>) => ({
     type: OVERWRITE_EDGES as typeof OVERWRITE_EDGES,
-    payload: edges,
+    payload: { edges },
   });
 
 /**
@@ -297,7 +297,7 @@ export const REMOVE_EDGES = 'REMOVE_EDGES';
 export const removeEdges =
   (edges: ObjectMap<Edge>) => ({
     type: REMOVE_EDGES as typeof REMOVE_EDGES,
-    payload: edges,
+    payload: { edges },
   });
 
 /**
@@ -344,18 +344,18 @@ export const reducer = (state: Storage = initial, action: Action = emptyAction):
     case UPDATE_OBJECTS: {
       return {
         ...state,
-        objects: { ...state.objects, ...action.payload },
+        objects: { ...state.objects, ...action.payload.objects },
       };
     }
     case OVERWRITE_OBJECTS: {
       return {
         ...state,
-        objects: action.payload,
+        objects: action.payload.objects,
       };
     }
     case REMOVE_OBJECTS: {
       const objects = { ...state.objects };
-      Object.keys(action.payload).forEach(key => delete objects[key]);
+      Object.keys(action.payload.objects).forEach(key => delete objects[key]);
 
       return {
         ...state,
@@ -365,18 +365,18 @@ export const reducer = (state: Storage = initial, action: Action = emptyAction):
     case UPDATE_CARDS: {
       return {
         ...state,
-        cards: { ...state.cards, ...action.payload },
+        cards: { ...state.cards, ...action.payload.cards },
       };
     }
     case OVERWRITE_CARDS: {
       return {
         ...state,
-        cards: action.payload,
+        cards: action.payload.cards,
       };
     }
     case REMOVE_CARDS: {
       const cards = { ...state.cards };
-      Object.keys(action.payload).forEach(key => delete cards[key]);
+      Object.keys(action.payload.cards).forEach(key => delete cards[key]);
 
       return {
         ...state,
@@ -386,18 +386,18 @@ export const reducer = (state: Storage = initial, action: Action = emptyAction):
     case UPDATE_BOXES: {
       return {
         ...state,
-        boxes: { ...state.boxes, ...action.payload },
+        boxes: { ...state.boxes, ...action.payload.boxes },
       };
     }
     case OVERWRITE_BOXES: {
       return {
         ...state,
-        boxes: action.payload,
+        boxes: action.payload.boxes,
       };
     }
     case REMOVE_BOXES: {
       const boxes = { ...state.boxes };
-      Object.keys(action.payload).forEach(key => delete boxes[key]);
+      Object.keys(action.payload.boxes).forEach(key => delete boxes[key]);
 
       return {
         ...state,
@@ -405,14 +405,14 @@ export const reducer = (state: Storage = initial, action: Action = emptyAction):
       };
     }
     case UPDATE_EDGES: {
-      return { ...state, edges: { ...state.edges, ...action.payload } };
+      return { ...state, edges: { ...state.edges, ...action.payload.edges } };
     }
     case OVERWRITE_EDGES: {
-      return { ...state, edges: action.payload };
+      return { ...state, edges: action.payload.edges };
     }
     case REMOVE_EDGES: {
       const edges = { ...state.edges };
-      Object.keys(action.payload).forEach(key => delete edges[key]);
+      Object.keys(action.payload.edges).forEach(key => delete edges[key]);
 
       return {
         ...state,

--- a/sensemap/src/types/storage.ts
+++ b/sensemap/src/types/storage.ts
@@ -1,0 +1,180 @@
+import { ObjectMap } from './sense/has-id';
+import { ObjectID, ObjectData, emptyObjectData } from './sense/object';
+import { CardID, CardData, emptyCardData } from './sense/card';
+import { BoxID, BoxData, emptyBoxData } from './sense/box';
+import { EdgeID, Edge, emptyEdge } from './sense/edge';
+
+/**
+ * The storage of sense objects.
+ */
+export type Storage = {
+  objects: ObjectMap<ObjectData>,
+  cards:   ObjectMap<CardData>,
+  boxes:   ObjectMap<BoxData>,
+  edges:   ObjectMap<Edge>,
+};
+
+export const initial: Storage = {
+  objects: {},
+  cards:   {},
+  boxes:   {},
+  edges:   {},
+};
+
+/**
+ * It gets an object by it's id.
+ *
+ * @param storage The storage.
+ * @param id The object id.
+ */
+export const getObject = (storage: Storage, id: ObjectID): ObjectData => storage.objects[id] || emptyObjectData;
+
+/**
+ * It gets a card by it's id.
+ *
+ * @param storage The storage.
+ * @param id The card id.
+ */
+export const getCard = (storage: Storage, id: CardID): CardData => storage.cards[id] || emptyCardData;
+
+/**
+ * It gets a box by it's id.
+ *
+ * @param storage The storage.
+ * @param id The box id.
+ */
+export const getBox = (storage: Storage, id: BoxID): BoxData => storage.boxes[id] || emptyBoxData;
+
+/**
+ * It gets an edge by it's id.
+ *
+ * @param storage The storage.
+ * @param id The edge id.
+ */
+export const getEdge = (storage: Storage, id: EdgeID): Edge => storage.edges[id] || emptyEdge;
+
+/**
+ * It gets cards from the given box.
+ *
+ * @param storage The storage.
+ * @param id The box id.
+ */
+export const getCardsInBox = (storage: Storage, id: BoxID): ObjectMap<CardData> =>
+  Object.keys(getBox(storage, id).contains)
+    .map(oid => getObject(storage, oid).data )
+    .map(cid => getCard(storage, cid))
+    .reduce((a, c) => { a[c.id] = c; return a; }, {});
+
+/**
+ * Check if an object exists.
+ *
+ * @param storage The storage.
+ * @param id The object id.
+ */
+export const doesObjectExist = (storage: Storage, id: ObjectID): boolean => !!storage.objects[id];
+
+/**
+ * Check if a card exists.
+ *
+ * @param storage The storage.
+ * @param id The card id.
+ */
+export const doesCardExist = (storage: Storage, id: CardID): boolean => !!storage.cards[id];
+
+/**
+ * Check if a box exists.
+ *
+ * @param storage The storage.
+ * @param id The card id.
+ */
+export const doesBoxExist = (storage: Storage, id: BoxID): boolean => !!storage.boxes[id];
+
+/**
+ * Check if an edge exists.
+ *
+ * @param storage The storage.
+ * @param id The card id.
+ */
+export const doesEdgeExist = (storage: Storage, id: EdgeID): boolean => !!storage.edges[id];
+
+/**
+ * It gets a card from a storage or fallback to another storage.
+ *
+ * @param storage The target storage.
+ * @param defaultStorage The fallback storage.
+ * @param id The card id.
+ */
+export const getCardOrDefault = (storage: Storage, defaultStorage: Storage, id: CardID): CardData =>
+  storage.cards[id] || defaultStorage.cards[id] || emptyCardData;
+
+/**
+ * It gets a box from a storage or fallback to another storage.
+ *
+ * @param storage The target storage.
+ * @param defaultStorage The fallback storage.
+ * @param id The box id.
+ */
+export const getBoxOrDefault = (storage: Storage, defaultStorage: Storage, id: BoxID): BoxData =>
+  storage.boxes[id] || defaultStorage.boxes[id] || emptyBoxData;
+
+/**
+ * It gets an edge from a storage or fallback to another storage.
+ *
+ * @param storage The target storage.
+ * @param defaultStorage The fallback storage.
+ * @param id The edge id.
+ */
+export const getEdgeOrDefault = (storage: Storage, defaultStorage: Storage, id: EdgeID): Edge =>
+  storage.edges[id] || defaultStorage.edges[id] || emptyEdge;
+
+/**
+ * It filters the storage objects and create a new storage with those objects
+ * and their edges.
+ *
+ * @todo Is it a `map`?
+ *
+ * @param storage The target storage.
+ * @param filter The filter function.
+ */
+export const scoped = (storage: Storage, filter: (key: ObjectID) => boolean): Storage => {
+  const objects = Object.keys(storage.objects)
+    .filter(filter)
+    .reduce(
+      (acc, key) => {
+        acc[key] = getObject(storage, key);
+        return acc;
+      },
+      {});
+  const edges = Object.values(storage.edges)
+    .filter(g => !!objects[g.from] && !!objects[g.to])
+    .reduce(
+      (acc, g) => {
+        acc[g.id] = g;
+        return acc;
+      },
+      {});
+  const { cards, boxes } = storage;
+  return { objects, cards, boxes, edges };
+};
+
+/**
+ * It gets a substorage with objects inside a box.
+ *
+ * @param storage The target storage.
+ * @param id The box id.
+ */
+export const scopedToBox = (storage: Storage, id: BoxID): Storage => {
+  const { contains } = getBox(storage, id);
+  const filter = (key: ObjectID): boolean => !!contains[key];
+  return scoped(storage, filter);
+};
+
+/**
+ * It gets a new storage with objects that are not in any box.
+ *
+ * @param storage The target storage.
+ */
+export const scopedToMap = (storage: Storage): Storage => {
+  const filter = (key: ObjectID): boolean => !getObject(storage, key).belongsTo;
+  return scoped(storage, filter);
+};


### PR DESCRIPTION
為了達成「邊編輯邊反映在 map 上」，並簡化 inspector 和 map 的結構，將 `senseObject` 的 `{ objects, cards, boxes, edges }` 結構（改稱為 `Storage` ）變成一個同時容納修改前後資料的結構。並提供相似的 API 。

這樣可以完成 #73 中大半重構，留下 selection, focus 待未來處理。